### PR TITLE
 Add session key expiration limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn-error.log*
 *.swp
 *.swo
 *~
+
+# Diff files
+diff.txt

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,6 +51,8 @@ pub enum ExternalSignatureProgramError {
     InvalidSessionKey,
     #[error("Session key expired")]
     SessionKeyExpired,
+    #[error("Invalid session key expiration")]
+    InvalidSessionKeyExpiration,
 
     /// Signature Scheme Related Errors
     #[error("Invalid signature scheme")]

--- a/src/state/externally_signed_account.rs
+++ b/src/state/externally_signed_account.rs
@@ -14,6 +14,8 @@ use pinocchio::{
 
 use crate::errors::ExternalSignatureProgramError;
 
+pub const SESSION_KEY_EXPIRATION_LIMIT: u64 = 3 * 30 * 24 * 60 * 60; // 3 months in seconds
+
 /// Version and type header for all account data
 #[derive(Pod, Zeroable, Copy, Clone)]
 #[repr(C)]


### PR DESCRIPTION
Description:
Implements a 3-month maximum expiration limit for session keys to enhance security. This change prevents session keys from being set with excessively long expiration times, reducing the risk of compromised session keys being valid indefinitely.

Changes:
- Add `SESSION_KEY_EXPIRATION_LIMIT` constant set to 3 months in seconds
- Add validation for session key expiration in initialization and update methods
- Introduce new error type `InvalidSessionKeyExpiration` for expiration validation
- Apply expiration limit checks in `P256WebauthnAccountData` state impl