### PR TITLE
Add signer execution scheme support and optimize account operations

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,6 +58,12 @@ pub enum ExternalSignatureProgramError {
     #[error("Invalid signature scheme")]
     InvalidSignatureScheme,
 
+    /// Signer Execution Scheme Related Errors
+    #[error("Invalid signer execution scheme")]
+    InvalidSignerExecutionScheme,
+    #[error("Signer execution account is not a signer")]
+    SignerExecutionAccountNotASigner,
+
     /// P256 WebAuthn Related Errors
     #[error("Relying party mismatch")]
     RelyingPartyMismatch,

--- a/src/instructions/execute_instructions.rs
+++ b/src/instructions/execute_instructions.rs
@@ -1,22 +1,14 @@
-use crate::{
-    state::{
-        AccountSeedsTrait, ExecutionAccount, ExternallySignedAccount, SignatureScheme,
-        SignerExecutionScheme,
-    },
-    utils::{
-        nonce::{validate_nonce, TruncatedSlot},
-        sha256::hash,
-        SlotHashes,
-    },
-};
+use crate::{state::{
+    AccountSeedsTrait, ExecutionAccount, ExternallySignedAccount, SignatureScheme,
+    SignerExecutionScheme,
+}, utils::{hash, validate_nonce, SlotHashes, TruncatedSlot}};
 use borsh::{BorshDeserialize, BorshSerialize};
 use num_enum::TryFromPrimitive;
 use pinocchio::{
     account_info::{AccountInfo, Ref},
     cpi::slice_invoke_signed,
-    instruction::{AccountMeta, Instruction, Seed, Signer},
+    instruction::{AccountMeta, Instruction, Signer},
     program_error::ProgramError,
-    seeds,
     sysvars::instructions::Instructions,
     ProgramResult,
 };
@@ -28,24 +20,24 @@ use crate::{
 };
 
 pub struct ExecuteInstructionsContext<'a, T: ExternallySignedAccountData> {
-    pub external_account: Box<ExternallySignedAccount<'a, T>>,
-    pub execution_account: ExecutionAccount<'a>,
+    pub external_account: ExternallySignedAccount<'a, T>,
+    pub execution_account: ExecutionAccount,
     pub signature_scheme_specific_verification_data: T::ParsedVerificationData,
-    pub instructions_sysvar_account: Box<Instructions<Ref<'a, [u8]>>>,
+    pub instructions_sysvar_account: Instructions<Ref<'a, [u8]>>,
     pub slothash: [u8; 32],
     pub signer_account: &'a AccountInfo,
-    pub instructions: Box<&'a [CompiledInstruction]>,
-    pub instruction_execution_accounts: Box<&'a [AccountInfo]>,
-    pub instruction_execution_account_metas: Box<Vec<AccountMeta<'a>>>,
+    pub instructions: &'a [CompiledInstruction],
+    pub instruction_execution_accounts: &'a [AccountInfo],
+    pub instruction_execution_account_metas: Vec<AccountMeta<'a>>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct ExecutableInstructionArgs {
     pub signature_scheme: u8,
+    pub signer_execution_scheme: u8,
     pub slothash: TruncatedSlot,
     pub extra_verification_data: SmallVec<u8, u8>,
     pub instructions: SmallVec<u8, CompiledInstruction>,
-    pub signer_execution_scheme: u8,
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]
@@ -83,7 +75,9 @@ impl<'a, T: ExternallySignedAccountData> ExecuteInstructionsContext<'a, T> {
         let signer_execution_scheme =
             SignerExecutionScheme::try_from_primitive(execution_args.signer_execution_scheme)
                 .map_err(|_| ExternalSignatureProgramError::InvalidSignerExecutionScheme)?;
+
         let external_account = ExternallySignedAccount::<T>::new(external_account)?;
+
         let execution_account = external_account.get_execution_account(signer_execution_scheme)?;
         let args = T::RawVerificationData::try_from_slice(
             &execution_args.extra_verification_data.as_slice(),
@@ -98,45 +92,16 @@ impl<'a, T: ExternallySignedAccountData> ExecuteInstructionsContext<'a, T> {
         let nonce_data =
             validate_nonce(slothashes_sysvar, &execution_args.slothash, signer_account)?;
 
-        let signer_execution_account = match signer_execution_scheme {
-            SignerExecutionScheme::ExternalAccount => external_account.account_info,
-            SignerExecutionScheme::ExecutionAccount => execution_account.account_info,
-        };
-
-        let execution_account_seeds = external_account.derive_existing_account()?;
-        let seeds = execution_account_seeds.seeds();
-        let external_account_signer_seeds =
-            seeds.iter().map(|s| Seed::from(*s)).collect::<Vec<Seed>>();
-        let execution_account_signer_seeds = execution_account.to_signer_seeds();
-
-        // validate the signer execution scheme
-        let signer: [Signer; 1] = match signer_execution_scheme {
-            SignerExecutionScheme::ExternalAccount => {
-                if !external_account.account_info.is_signer() {
-                    return Err(
-                        ExternalSignatureProgramError::SignerExecutionAccountNotASigner.into(),
-                    );
-                }
-
-                let signer = [Signer::from(external_account_signer_seeds.as_slice())];
-
-                signer
-            }
-            SignerExecutionScheme::ExecutionAccount => {
-                let signer = [Signer::from(execution_account_signer_seeds.as_slice())];
-
-                signer
-            }
-        };
-
         let instruction_execution_account_metas = instruction_execution_accounts
             .iter()
             .map(
-                |account| match account.key() == signer_execution_account.key() {
+                |account| match account.key() == &execution_account.key {
                     // The execution account needs to be set to be a signer for the
                     // later instruction execution
                     true => match signer_execution_scheme {
                         SignerExecutionScheme::ExternalAccount => {
+                            // If we're directly signing with the external
+                            // account, we want to do so with marked as non-mutable
                             AccountMeta::new(account.key(), false, true)
                         }
                         SignerExecutionScheme::ExecutionAccount => {
@@ -144,22 +109,22 @@ impl<'a, T: ExternallySignedAccountData> ExecuteInstructionsContext<'a, T> {
                         }
                     },
                     _ => {
+                        // All other accounts, use as they are passed in
                         AccountMeta::new(account.key(), account.is_writable(), account.is_signer())
                     }
                 },
             )
             .collect();
-
         Ok(Box::new(Self {
-            external_account: Box::new(external_account),
+            external_account: external_account,
             execution_account,
             signature_scheme_specific_verification_data: parsed_verification_data,
-            instructions_sysvar_account: Box::new(instructions_sysvar),
+            instructions_sysvar_account: instructions_sysvar,
             signer_account,
-            instruction_execution_accounts: Box::new(instruction_execution_accounts),
-            instruction_execution_account_metas: Box::new(instruction_execution_account_metas),
+            instruction_execution_accounts: instruction_execution_accounts,
+            instruction_execution_account_metas: instruction_execution_account_metas,
             slothash: nonce_data.slothash,
-            instructions: Box::new(execution_args.instructions.as_slice()),
+            instructions: execution_args.instructions.as_slice(),
         }))
     }
 
@@ -179,7 +144,6 @@ impl<'a, T: ExternallySignedAccountData> ExecuteInstructionsContext<'a, T> {
         for instruction in self.instructions.iter() {
             instruction.serialize(&mut instruction_payload).unwrap();
         }
-        //self.instructions.serialize(&mut instruction_payload).unwrap();
         hash(&instruction_payload)
     }
 }
@@ -189,9 +153,6 @@ pub fn process_execute_instructions(accounts: &[AccountInfo], data: &[u8]) -> Pr
         .map_err(|_| ExternalSignatureProgramError::InvalidExecutionArgs)?;
     let signature_scheme = SignatureScheme::try_from_primitive(args.signature_scheme)
         .map_err(|_| ExternalSignatureProgramError::InvalidSignatureScheme)?;
-    let signer_execution_type =
-        SignerExecutionScheme::try_from_primitive(args.signer_execution_scheme)
-            .map_err(|_| ExternalSignatureProgramError::InvalidSignerExecutionScheme)?;
 
     let mut execution_context = match signature_scheme {
         SignatureScheme::P256Webauthn => {

--- a/src/signatures/p256/client.rs
+++ b/src/signatures/p256/client.rs
@@ -93,7 +93,8 @@ pub fn reconstruct_client_data_json(
     } else {
         "https://"
     };
-    let origin = format!("{}{}", prefix, std::str::from_utf8(rp_id).unwrap());
+    let suffix = ":3000";
+    let origin = format!("{}{}{}", prefix, std::str::from_utf8(rp_id).unwrap(), suffix);
     let cross_origin = if params.is_cross_origin() {
         "true"
     } else {

--- a/src/state/p256.rs
+++ b/src/state/p256.rs
@@ -3,9 +3,11 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use bytemuck::{Pod, Zeroable};
 use pinocchio::{
     account_info::{AccountInfo, Ref},
+    instruction::{Seed, Signer},
     log::sol_log,
     program_error::ProgramError,
     pubkey::{try_find_program_address, Pubkey},
+    seeds,
     sysvars::{clock::Clock, instructions::Instructions, Sysvar},
 };
 
@@ -15,8 +17,7 @@ use crate::{
         reconstruct_client_data_json, AuthDataParser, ClientDataJsonReconstructionParams,
     },
     state::{
-        AccountHeader, AccountSeedsTrait, ExternallySignedAccountData, SessionKey, SignatureScheme,
-        SESSION_KEY_EXPIRATION_LIMIT,
+        AccountHeader, AccountSeeds, AccountSeedsTrait, ExternallySignedAccountData, SessionKey, SignatureScheme, SESSION_KEY_EXPIRATION_LIMIT
     },
     utils::{hash, PrecompileParser, Secp256r1Precompile, SmallVec, HASH_LENGTH},
 };
@@ -159,29 +160,6 @@ impl RpIdInformation {
     }
 }
 
-pub struct AccountSeeds {
-    pub key: Pubkey,
-    pub bump: u8,
-    seed_passkey: &'static [u8],
-    seed_public_key_hash: [u8; 32],
-}
-
-impl AccountSeedsTrait for AccountSeeds {
-    fn key(&self) -> &Pubkey {
-        &self.key
-    }
-    fn bump(&self) -> u8 {
-        self.bump
-    }
-    fn seeds(&self) -> Vec<&[u8]> {
-        vec![
-            self.seed_passkey,
-            &self.seed_public_key_hash,
-            core::slice::from_ref(&self.bump),
-        ]
-    }
-}
-
 impl ExternallySignedAccountData for P256WebauthnAccountData {
     type AccountSeeds = AccountSeeds;
     type DeriveAccountArgs = P256DeriveAccountArgs;
@@ -224,10 +202,11 @@ impl ExternallySignedAccountData for P256WebauthnAccountData {
         Ok(())
     }
 
-    fn derive_account<'a>(args: Self::DeriveAccountArgs) -> Result<AccountSeeds, ProgramError> {
+    fn derive_account(args: Self::DeriveAccountArgs) -> Result<Self::AccountSeeds, ProgramError> {
         let public_key_hash = hash(&args.public_key);
-        let seeds: [&[u8]; 2] = [b"passkey", &public_key_hash];
-        let (derived_key, bump) = try_find_program_address(&seeds, &crate::ID).unwrap();
+        let (derived_key, bump) =
+            try_find_program_address(&[b"passkey", &public_key_hash], &crate::ID).unwrap();
+
         Ok(AccountSeeds {
             key: derived_key,
             bump,
@@ -236,7 +215,15 @@ impl ExternallySignedAccountData for P256WebauthnAccountData {
         })
     }
 
-    fn check_account<'a>(
+    fn derive_existing_account(&self) -> Result<Self::AccountSeeds, ProgramError> {
+        let seeds = Self::derive_account(Self::DeriveAccountArgs {
+            public_key: self.public_key.to_bytes(),
+        })?;
+
+        Ok(seeds)
+    }
+
+    fn check_account(
         &self,
         account_info: &AccountInfo,
         _args: &Self::ParsedVerificationData,

--- a/src/state/p256.rs
+++ b/src/state/p256.rs
@@ -22,6 +22,8 @@ use crate::{
     utils::{hash, PrecompileParser, Secp256r1Precompile, SmallVec, HASH_LENGTH},
 };
 
+use super::ExecutionAccount;
+
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
 pub struct P256RawInitializationData {
     pub rp_id: SmallVec<u8, u8>,
@@ -274,11 +276,9 @@ impl ExternallySignedAccountData for P256WebauthnAccountData {
             &rp_id,
             &payload,
         );
-        let base_64_payload = general_purpose::URL_SAFE_NO_PAD.encode(&payload);
-        let base_64_reconstructed_client_data =
-            general_purpose::URL_SAFE_NO_PAD.encode(&reconstructed_client_data);
-        sol_log(&base_64_payload);
-        sol_log(&base_64_reconstructed_client_data);
+        // let base_64_payload = general_purpose::URL_SAFE_NO_PAD.encode(&payload);
+        // let base_64_reconstructed_client_data =
+        //     general_purpose::URL_SAFE_NO_PAD.encode(&reconstructed_client_data);
 
         let reconstructed_client_data_hash = hash(&reconstructed_client_data);
 
@@ -318,8 +318,6 @@ impl ExternallySignedAccountData for P256WebauthnAccountData {
         if self.session_key.expiration < clock.unix_timestamp as u64 {
             return Err(ExternalSignatureProgramError::SessionKeyExpired.into());
         }
-        sol_log(format!("Session Key Expiration: {:?}", self.session_key.expiration).as_str());
-        sol_log(format!("Clock Timestamp: {:?}", clock.unix_timestamp).as_str());
         Ok(())
     }
 

--- a/src/state/p256.rs
+++ b/src/state/p256.rs
@@ -199,6 +199,7 @@ impl ExternallySignedAccountData for P256WebauthnAccountData {
         self.rp_id_info = args.rp_id_info;
         self.public_key = args.public_key;
         self.counter = args.counter;
+        // Set as default
         self.session_key = args.session_key;
 
         Ok(())

--- a/src/utils/nonce.rs
+++ b/src/utils/nonce.rs
@@ -15,10 +15,6 @@ pub struct TruncatedSlot(pub u32);
 
 impl TruncatedSlot {
     pub fn new(untruncated_slot: u64) -> Result<Self, ProgramError> {
-        // We only expect truncated slots to be 0 - 999
-        if untruncated_slot > 999 {
-            return Err(ExternalSignatureProgramError::InvalidTruncatedSlot.into());
-        }
         let slot = untruncated_slot % 1000;
         Ok(Self(slot as u32))
     }

--- a/tests/p256/utils/authentication.rs
+++ b/tests/p256/utils/authentication.rs
@@ -39,7 +39,7 @@ pub fn authenticate_passkey_account(
         &webauthn_data.signature,
         &message_data,
         &public_key,
-        Some((1, 7)),
+        Some((1, 8)),
     )
     .unwrap();
 
@@ -51,6 +51,7 @@ pub fn authenticate_passkey_account(
     };
 
     let execution_account = get_execution_account(passkey_account.clone(), program_id.clone());
+    println!("execution_account: {:?}", execution_account.to_string());
     svm.airdrop(&execution_account, 1000000000).unwrap();
 
     let memo_instruction = create_memo_instruction();
@@ -61,6 +62,7 @@ pub fn authenticate_passkey_account(
     let serialized_compiled_instruction = serialize_compiled_instruction(compiled_instruction);
     let external_sig_ix_data = ExecutableInstructionArgs {
         signature_scheme: 0,
+        signer_execution_scheme: 0,
         extra_verification_data: SmallVec::<u8, u8>::from(
             to_vec(&extra_verification_data).unwrap(),
         ),

--- a/tests/p256/utils/execute_sessioned_instructions.rs
+++ b/tests/p256/utils/execute_sessioned_instructions.rs
@@ -29,6 +29,7 @@ pub fn execute_sessioned_instructions(
     let serialized_compiled_instruction = serialize_compiled_instruction(compiled_instruction);
     let external_sig_ix_data = ExecutableInstructionSessionedArgs {
         signature_scheme: 0,
+        signer_execution_scheme: 0,
         instructions: serialized_compiled_instruction,
     };
     let mut serialized_ix_data: Vec<u8> = vec![];

--- a/tests/p256/utils/initialization.rs
+++ b/tests/p256/utils/initialization.rs
@@ -74,6 +74,7 @@ pub fn initialize_passkey_account(
         signature_scheme: SignatureScheme::P256Webauthn.into(),
         initialization_data: SmallVec::<u8, u8>::try_from(to_vec(&p256_webauthn_args).unwrap())
             .unwrap(),
+        session_key: None,
     };
 
     let mut instruction_data = Vec::with_capacity(1 + 1 + public_key.len() + 1 + rp_id.len());

--- a/tests/p256/utils/instruction_and_payload_generation.rs
+++ b/tests/p256/utils/instruction_and_payload_generation.rs
@@ -22,9 +22,8 @@ use crate::{
 };
 
 pub fn get_execution_account(account: Pubkey, program_id: Pubkey) -> Pubkey {
-    let (execution_account, _bump) =
-        Pubkey::try_find_program_address(&[account.as_ref(), b"execution_account"], &program_id)
-            .unwrap();
+    let seeds = [account.as_ref(), b"execution_account"];
+    let (execution_account, _bump) = Pubkey::try_find_program_address(&seeds, &program_id).unwrap();
     execution_account
 }
 pub fn serialize_compiled_instruction(


### PR DESCRIPTION
# Description
Introduces a new `SignerExecutionScheme` enum to allow direct external account signing, reducing transaction overhead. Also includes improvements to session key handling, client data validation, and general code optimizations.

# Changes
- Added `SignerExecutionScheme` with two modes:
  - `ExecutionAccount` (legacy/default) - uses derived execution account as signer
  - `ExternalAccount` - uses externally signed account directly as signer
- Enhanced error handling with new error types for signer execution validation
- Optimized memory usage by removing unnecessary Box allocations in execution contexts
- Updated P256 WebAuthn client data reconstruction to include port 3000
- Improved session key validation and handling
- Removed unnecessary slot validation in TruncatedSlot
- Added support for owned seeds in account operations
- Updated tests to accommodate new signer execution scheme