### PR TITLE
feat: add Codama IDL for Solana Explorer

### DIFF
--- a/codama/codama.ts
+++ b/codama/codama.ts
@@ -1,0 +1,819 @@
+import {
+    accountNode,
+    arrayTypeNode,
+    bytesTypeNode,
+    constantDiscriminatorNode,
+    constantPdaSeedNodeFromString,
+    constantValueNode,
+    createFromRoot,
+    definedTypeLinkNode,
+    definedTypeNode,
+    enumEmptyVariantTypeNode,
+    enumTypeNode,
+    errorNode,
+    fixedSizeTypeNode,
+    instructionAccountNode,
+    instructionArgumentNode,
+    instructionNode,
+    instructionRemainingAccountsNode,
+    numberTypeNode,
+    numberValueNode,
+    optionTypeNode,
+    pdaNode,
+    prefixedCountNode,
+    programNode,
+    publicKeyTypeNode,
+    publicKeyValueNode,
+    rootNode,
+    sizePrefixTypeNode,
+    structFieldTypeNode,
+    structTypeNode,
+    variablePdaSeedNode,
+} from "codama";
+import path from "path";
+import fs from "fs";
+
+// ============================================================================
+// External Signature Program — Codama IDL
+// ============================================================================
+//
+// Program ID: ExtSgUPtP3JyKUysFw2S5fpL5fWfUPzGUQLd2bTwftXN
+//
+// Instructions (discriminator = first byte):
+//   0 — initializeExternalAccount
+//   1 — executeInstructions
+//   2 — refreshSessionKey
+//   3 — executeInstructionsSessioned
+//
+// ============================================================================
+
+const root = rootNode(
+    programNode({
+        name: "externalSignatureProgram",
+        publicKey: "ExtSgUPtP3JyKUysFw2S5fpL5fWfUPzGUQLd2bTwftXN",
+        version: "0.1.0",
+        origin: "native",
+
+        // ====================================================================
+        // Accounts
+        // ====================================================================
+        accounts: [
+            // P256WebauthnAccountData — the on-chain account layout
+            // Layout: AccountHeader (4) + RpIdInformation (65) +
+            //         CompressedP256PublicKey (33) + padding (2) +
+            //         SessionKey (40) + counter (8) = 152 bytes
+            accountNode({
+                name: "p256WebauthnAccount",
+                size: 152,
+                discriminators: [
+                    // version=1, scheme=0 (P256Webauthn)
+                    constantDiscriminatorNode(
+                        constantValueNode(numberTypeNode("u8"), numberValueNode(1)),
+                        0
+                    ),
+                ],
+                data: structTypeNode([
+                    // --- AccountHeader (4 bytes) ---
+                    structFieldTypeNode({
+                        name: "version",
+                        type: numberTypeNode("u8"),
+                        defaultValue: numberValueNode(1),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    structFieldTypeNode({
+                        name: "scheme",
+                        type: numberTypeNode("u8"),
+                        defaultValue: numberValueNode(0),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    structFieldTypeNode({
+                        name: "reserved",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 2),
+                        defaultValue: numberValueNode(0),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    // --- RpIdInformation (65 bytes) ---
+                    structFieldTypeNode({
+                        name: "rpIdLen",
+                        type: numberTypeNode("u8"),
+                    }),
+                    structFieldTypeNode({
+                        name: "rpId",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 32),
+                        docs: ["Relying party ID, padded to 32 bytes"],
+                    }),
+                    structFieldTypeNode({
+                        name: "rpIdHash",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 32),
+                        docs: ["SHA-256 hash of the relying party ID"],
+                    }),
+                    // --- CompressedP256PublicKey (33 bytes) ---
+                    structFieldTypeNode({
+                        name: "publicKeyX",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 32),
+                        docs: ["X coordinate of the P256 public key"],
+                    }),
+                    structFieldTypeNode({
+                        name: "publicKeyYParity",
+                        type: numberTypeNode("u8"),
+                        docs: ["Y parity byte (0x02 or 0x03)"],
+                    }),
+                    // --- Padding (2 bytes) ---
+                    structFieldTypeNode({
+                        name: "padding",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 2),
+                        defaultValue: numberValueNode(0),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    // --- SessionKey (40 bytes) ---
+                    structFieldTypeNode({
+                        name: "sessionKeyPublicKey",
+                        type: publicKeyTypeNode(),
+                        docs: ["Ed25519 public key of the session key (zeroed if none)"],
+                    }),
+                    structFieldTypeNode({
+                        name: "sessionKeyExpiration",
+                        type: numberTypeNode("u64"),
+                        docs: ["Unix timestamp when the session key expires"],
+                    }),
+                    // --- Counter (8 bytes) ---
+                    structFieldTypeNode({
+                        name: "counter",
+                        type: numberTypeNode("u64"),
+                        docs: [
+                            "WebAuthn signature counter for replay protection.",
+                            "Must be monotonically increasing.",
+                        ],
+                    }),
+                ]),
+            }),
+        ],
+
+        // ====================================================================
+        // Instructions
+        // ====================================================================
+        instructions: [
+            // ----------------------------------------------------------------
+            // 0 — Initialize External Account
+            // ----------------------------------------------------------------
+            // Accounts: [externally_signed_account, rent_payer,
+            //            instructions_sysvar, slothashes_sysvar,
+            //            system_program, ...remaining]
+            // Data (borsh): TruncatedSlot(u16), signature_scheme(u8),
+            //               initialization_data(SmallVec<u8,u8>),
+            //               session_key(Option<SessionKey>)
+            instructionNode({
+                name: "initializeExternalAccount",
+                docs: [
+                    "Initializes a new externally-signed account with WebAuthn/P256 credentials.",
+                    "A secp256r1 precompile instruction must precede this instruction in the transaction.",
+                ],
+                optionalAccountStrategy: "omitted",
+                accounts: [
+                    instructionAccountNode({
+                        name: "externallySignedAccount",
+                        isSigner: false,
+                        isWritable: true,
+                        docs: ["The PDA to be created, derived from hash of compressed public key."],
+                    }),
+                    instructionAccountNode({
+                        name: "rentPayer",
+                        isSigner: true,
+                        isWritable: true,
+                        docs: ["The account paying for rent and transaction fees."],
+                    }),
+                    instructionAccountNode({
+                        name: "instructionsSysvar",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "Sysvar1nstructions1111111111111111111111111",
+                            "splInstructions"
+                        ),
+                        docs: ["Instructions sysvar for precompile signature introspection."],
+                    }),
+                    instructionAccountNode({
+                        name: "slotHashesSysvar",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "SysvarS1otHashes111111111111111111111111111",
+                            "splSlotHashes"
+                        ),
+                        docs: ["SlotHashes sysvar for nonce validation."],
+                    }),
+                    instructionAccountNode({
+                        name: "systemProgram",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "11111111111111111111111111111111",
+                            "systemProgram"
+                        ),
+                        docs: ["System Program for account creation."],
+                    }),
+                ],
+                arguments: [
+                    instructionArgumentNode({
+                        name: "discriminator",
+                        type: numberTypeNode("u8"),
+                        defaultValue: numberValueNode(0),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    instructionArgumentNode({
+                        name: "slothash",
+                        type: numberTypeNode("u16"),
+                        docs: [
+                            "Truncated slot (last 3 digits of slot height, mod 1000).",
+                            "Used as nonce — must match a recent slot hash (within 150 slots).",
+                        ],
+                    }),
+                    instructionArgumentNode({
+                        name: "signatureScheme",
+                        type: definedTypeLinkNode("signatureScheme"),
+                        docs: ["The signature scheme (currently only P256Webauthn = 0)."],
+                    }),
+                    instructionArgumentNode({
+                        name: "initializationData",
+                        type: sizePrefixTypeNode(
+                            bytesTypeNode(),
+                            numberTypeNode("u8")
+                        ),
+                        docs: [
+                            "Scheme-specific initialization data as SmallVec<u8, u8>.",
+                            "For P256Webauthn: borsh-serialized P256RawInitializationData",
+                            "(rp_id: SmallVec<u8,u8>, public_key: [u8;33],",
+                            " client_data_json_reconstruction_params: ClientDataJsonReconstructionParams).",
+                        ],
+                    }),
+                    instructionArgumentNode({
+                        name: "sessionKey",
+                        type: optionTypeNode(
+                            definedTypeLinkNode("sessionKey"),
+                            { prefix: numberTypeNode("u8") }
+                        ),
+                        docs: [
+                            "Optional session key. If provided, its expiration must not exceed",
+                            "3 months from the current Clock timestamp.",
+                        ],
+                    }),
+                ],
+                discriminators: [
+                    constantDiscriminatorNode(
+                        constantValueNode(numberTypeNode("u8"), numberValueNode(0))
+                    ),
+                ],
+            }),
+
+            // ----------------------------------------------------------------
+            // 1 — Execute Instructions
+            // ----------------------------------------------------------------
+            // Accounts: [externally_signed_account, instructions_sysvar,
+            //            slothashes_sysvar, nonce_signer,
+            //            ...instruction_execution_accounts]
+            // Data (borsh): signature_scheme(u8), signer_execution_scheme(u8),
+            //               slothash(TruncatedSlot/u16),
+            //               extra_verification_data(SmallVec<u8,u8>),
+            //               instructions(SmallVec<u8, CompiledInstruction>)
+            instructionNode({
+                name: "executeInstructions",
+                docs: [
+                    "Executes a batch of compiled instructions authenticated by a direct P256 signature.",
+                    "A secp256r1 precompile instruction must precede this instruction in the transaction.",
+                    "Includes reentrancy protection (cannot CPI back to this program).",
+                ],
+                optionalAccountStrategy: "omitted",
+                accounts: [
+                    instructionAccountNode({
+                        name: "externallySignedAccount",
+                        isSigner: false,
+                        isWritable: true,
+                        docs: ["The externally-signed PDA that authorizes the instructions."],
+                    }),
+                    instructionAccountNode({
+                        name: "instructionsSysvar",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "Sysvar1nstructions1111111111111111111111111",
+                            "splInstructions"
+                        ),
+                        docs: ["Instructions sysvar for precompile signature verification."],
+                    }),
+                    instructionAccountNode({
+                        name: "slotHashesSysvar",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "SysvarS1otHashes111111111111111111111111111",
+                            "splSlotHashes"
+                        ),
+                        docs: ["SlotHashes sysvar for nonce validation."],
+                    }),
+                    instructionAccountNode({
+                        name: "nonceSigner",
+                        isSigner: true,
+                        isWritable: false,
+                        docs: ["The signer providing the nonce signature for replay protection."],
+                    }),
+                ],
+                arguments: [
+                    instructionArgumentNode({
+                        name: "discriminator",
+                        type: numberTypeNode("u8"),
+                        defaultValue: numberValueNode(1),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    instructionArgumentNode({
+                        name: "signatureScheme",
+                        type: definedTypeLinkNode("signatureScheme"),
+                    }),
+                    instructionArgumentNode({
+                        name: "signerExecutionScheme",
+                        type: definedTypeLinkNode("signerExecutionScheme"),
+                        docs: [
+                            "Determines which account signs CPI calls:",
+                            "ExecutionAccount (0) = derived PDA, ExternalAccount (1) = the ESA itself.",
+                        ],
+                    }),
+                    instructionArgumentNode({
+                        name: "slothash",
+                        type: numberTypeNode("u16"),
+                        docs: ["Truncated slot for nonce validation (mod 1000)."],
+                    }),
+                    instructionArgumentNode({
+                        name: "extraVerificationData",
+                        type: sizePrefixTypeNode(
+                            bytesTypeNode(),
+                            numberTypeNode("u8")
+                        ),
+                        docs: [
+                            "Scheme-specific verification data as SmallVec<u8, u8>.",
+                            "For P256Webauthn: borsh-serialized P256RawVerificationData",
+                            "(public_key: [u8;33], client_data_json_reconstruction_params).",
+                        ],
+                    }),
+                    instructionArgumentNode({
+                        name: "instructions",
+                        type: arrayTypeNode(
+                            definedTypeLinkNode("compiledInstruction"),
+                            prefixedCountNode(numberTypeNode("u8"))
+                        ),
+                        docs: [
+                            "SmallVec<u8, CompiledInstruction> — compiled instructions to execute via CPI.",
+                            "Account indices reference the remaining accounts.",
+                        ],
+                    }),
+                ],
+                discriminators: [
+                    constantDiscriminatorNode(
+                        constantValueNode(numberTypeNode("u8"), numberValueNode(1))
+                    ),
+                ],
+                remainingAccounts: [
+                    instructionRemainingAccountsNode({
+                        isOptional: false,
+                        isSigner: false,
+                        isWritable: false,
+                        docs: [
+                            "Accounts referenced by the compiled instructions.",
+                            "The execution account (derived PDA or ESA itself, based on",
+                            "signerExecutionScheme) should be included here when needed.",
+                        ],
+                    }),
+                ],
+            }),
+
+            // ----------------------------------------------------------------
+            // 2 — Refresh Session Key
+            // ----------------------------------------------------------------
+            // Accounts: [externally_signed_account, instructions_sysvar,
+            //            slothashes_sysvar, nonce_signer, ...remaining]
+            // Data (borsh): slothash(u16), signature_scheme(u8),
+            //               verification_data(SmallVec<u8,u8>),
+            //               session_key(SessionKey)
+            instructionNode({
+                name: "refreshSessionKey",
+                docs: [
+                    "Refreshes the session key on an externally-signed account.",
+                    "Requires a fresh P256 signature. The new expiration is calculated as",
+                    "Clock::unix_timestamp + session_key.expiration (treated as a duration).",
+                ],
+                optionalAccountStrategy: "omitted",
+                accounts: [
+                    instructionAccountNode({
+                        name: "externallySignedAccount",
+                        isSigner: false,
+                        isWritable: true,
+                        docs: ["The externally-signed PDA whose session key is being refreshed."],
+                    }),
+                    instructionAccountNode({
+                        name: "instructionsSysvar",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "Sysvar1nstructions1111111111111111111111111",
+                            "splInstructions"
+                        ),
+                    }),
+                    instructionAccountNode({
+                        name: "slotHashesSysvar",
+                        isSigner: false,
+                        isWritable: false,
+                        defaultValue: publicKeyValueNode(
+                            "SysvarS1otHashes111111111111111111111111111",
+                            "splSlotHashes"
+                        ),
+                    }),
+                    instructionAccountNode({
+                        name: "nonceSigner",
+                        isSigner: true,
+                        isWritable: false,
+                        docs: ["The signer providing the nonce signature."],
+                    }),
+                ],
+                arguments: [
+                    instructionArgumentNode({
+                        name: "discriminator",
+                        type: numberTypeNode("u8"),
+                        defaultValue: numberValueNode(2),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    instructionArgumentNode({
+                        name: "slothash",
+                        type: numberTypeNode("u16"),
+                        docs: ["Truncated slot for nonce validation (mod 1000)."],
+                    }),
+                    instructionArgumentNode({
+                        name: "signatureScheme",
+                        type: definedTypeLinkNode("signatureScheme"),
+                    }),
+                    instructionArgumentNode({
+                        name: "verificationData",
+                        type: sizePrefixTypeNode(
+                            bytesTypeNode(),
+                            numberTypeNode("u8")
+                        ),
+                        docs: [
+                            "Scheme-specific verification data as SmallVec<u8, u8>.",
+                            "For P256Webauthn: borsh-serialized P256RawVerificationData.",
+                        ],
+                    }),
+                    instructionArgumentNode({
+                        name: "sessionKey",
+                        type: definedTypeLinkNode("sessionKey"),
+                        docs: [
+                            "The new session key. The expiration field is treated as a",
+                            "duration (seconds) — the program adds it to Clock::unix_timestamp.",
+                        ],
+                    }),
+                ],
+                discriminators: [
+                    constantDiscriminatorNode(
+                        constantValueNode(numberTypeNode("u8"), numberValueNode(2))
+                    ),
+                ],
+            }),
+
+            // ----------------------------------------------------------------
+            // 3 — Execute Instructions (Sessioned)
+            // ----------------------------------------------------------------
+            // Accounts: [externally_signed_account, session_signer,
+            //            ...instruction_execution_accounts]
+            // Data (borsh): signature_scheme(u8), signer_execution_scheme(u8),
+            //               instructions(SmallVec<u8, CompiledInstruction>)
+            instructionNode({
+                name: "executeInstructionsSessioned",
+                docs: [
+                    "Executes compiled instructions using an active session key.",
+                    "No precompile signature required — the session key signer authorizes execution.",
+                    "Validates session key against the account and checks expiration.",
+                    "Includes reentrancy protection.",
+                ],
+                optionalAccountStrategy: "omitted",
+                accounts: [
+                    instructionAccountNode({
+                        name: "externallySignedAccount",
+                        isSigner: false,
+                        isWritable: true,
+                        docs: ["The externally-signed PDA that authorizes the instructions."],
+                    }),
+                    instructionAccountNode({
+                        name: "sessionSigner",
+                        isSigner: true,
+                        isWritable: false,
+                        docs: ["The session key signer — must match the key stored on the account."],
+                    }),
+                ],
+                arguments: [
+                    instructionArgumentNode({
+                        name: "discriminator",
+                        type: numberTypeNode("u8"),
+                        defaultValue: numberValueNode(3),
+                        defaultValueStrategy: "omitted",
+                    }),
+                    instructionArgumentNode({
+                        name: "signatureScheme",
+                        type: definedTypeLinkNode("signatureScheme"),
+                    }),
+                    instructionArgumentNode({
+                        name: "signerExecutionScheme",
+                        type: definedTypeLinkNode("signerExecutionScheme"),
+                        docs: [
+                            "ExecutionAccount (0) = derived PDA signs,",
+                            "ExternalAccount (1) = ESA itself signs.",
+                        ],
+                    }),
+                    instructionArgumentNode({
+                        name: "instructions",
+                        type: arrayTypeNode(
+                            definedTypeLinkNode("compiledInstruction"),
+                            prefixedCountNode(numberTypeNode("u8"))
+                        ),
+                        docs: [
+                            "SmallVec<u8, CompiledInstruction> — compiled instructions to execute.",
+                        ],
+                    }),
+                ],
+                discriminators: [
+                    constantDiscriminatorNode(
+                        constantValueNode(numberTypeNode("u8"), numberValueNode(3))
+                    ),
+                ],
+                remainingAccounts: [
+                    instructionRemainingAccountsNode({
+                        isOptional: false,
+                        isSigner: false,
+                        isWritable: false,
+                        docs: ["Accounts referenced by the compiled instructions."],
+                    }),
+                ],
+            }),
+        ],
+
+        // ====================================================================
+        // Defined Types
+        // ====================================================================
+        definedTypes: [
+            // SignatureScheme enum
+            definedTypeNode({
+                name: "signatureScheme",
+                type: enumTypeNode([
+                    enumEmptyVariantTypeNode("p256Webauthn"),
+                ]),
+                docs: [
+                    "The signature verification scheme.",
+                    "Currently only P256Webauthn (0) is supported.",
+                ],
+            }),
+
+            // SignerExecutionScheme enum
+            definedTypeNode({
+                name: "signerExecutionScheme",
+                type: enumTypeNode([
+                    enumEmptyVariantTypeNode("executionAccount"),
+                    enumEmptyVariantTypeNode("externalAccount"),
+                ]),
+                docs: [
+                    "Determines which account signs CPI calls.",
+                    "ExecutionAccount: a derived PDA (ESA key + 'execution_account').",
+                    "ExternalAccount: the externally-signed account itself.",
+                ],
+            }),
+
+            // SessionKey struct (borsh-serialized in instruction data)
+            definedTypeNode({
+                name: "sessionKey",
+                type: structTypeNode([
+                    structFieldTypeNode({
+                        name: "key",
+                        type: publicKeyTypeNode(),
+                        docs: ["Ed25519 public key of the session key."],
+                    }),
+                    structFieldTypeNode({
+                        name: "expiration",
+                        type: numberTypeNode("u64"),
+                        docs: [
+                            "For initialization/refresh: duration in seconds to add to current timestamp.",
+                            "On-chain: absolute unix timestamp of expiration.",
+                            "Max 3 months (7,776,000 seconds) from current time.",
+                        ],
+                    }),
+                ]),
+                docs: ["An ephemeral session key with an expiration."],
+            }),
+
+            // CompiledInstruction struct (borsh-serialized)
+            definedTypeNode({
+                name: "compiledInstruction",
+                type: structTypeNode([
+                    structFieldTypeNode({
+                        name: "programIdIndex",
+                        type: numberTypeNode("u8"),
+                        docs: ["Index into the remaining accounts for the program to invoke."],
+                    }),
+                    structFieldTypeNode({
+                        name: "accountsIndices",
+                        type: arrayTypeNode(
+                            numberTypeNode("u8"),
+                            prefixedCountNode(numberTypeNode("u8"))
+                        ),
+                        docs: [
+                            "SmallVec<u8, u8> — indices into remaining accounts for this instruction.",
+                        ],
+                    }),
+                    structFieldTypeNode({
+                        name: "data",
+                        type: arrayTypeNode(
+                            numberTypeNode("u8"),
+                            prefixedCountNode(numberTypeNode("u16"))
+                        ),
+                        docs: [
+                            "SmallVec<u16, u8> — the instruction data (u16 length prefix).",
+                        ],
+                    }),
+                ]),
+                docs: [
+                    "A compiled instruction that references accounts by index into the",
+                    "remaining accounts array. Uses SmallVec (u8/u16 length prefixes).",
+                ],
+            }),
+
+            // ClientDataJsonReconstructionParams
+            definedTypeNode({
+                name: "clientDataJsonReconstructionParams",
+                type: structTypeNode([
+                    structFieldTypeNode({
+                        name: "typeAndFlags",
+                        type: numberTypeNode("u8"),
+                        docs: [
+                            "Packed byte: high nibble = auth type (0x00=create, 0x10=get),",
+                            "low nibble = flags (0x01=crossOrigin, 0x02=http, 0x04=googleExtra).",
+                        ],
+                    }),
+                    structFieldTypeNode({
+                        name: "port",
+                        type: optionTypeNode(
+                            numberTypeNode("u16"),
+                            { prefix: numberTypeNode("u8") }
+                        ),
+                        docs: ["Optional port number for the origin URL."],
+                    }),
+                ]),
+                docs: [
+                    "Minimal representation for reconstructing the WebAuthn clientDataJSON.",
+                    "Used in both initialization and verification data.",
+                ],
+            }),
+
+            // P256RawInitializationData — what goes inside initializationData bytes
+            definedTypeNode({
+                name: "p256RawInitializationData",
+                type: structTypeNode([
+                    structFieldTypeNode({
+                        name: "rpId",
+                        type: arrayTypeNode(
+                            numberTypeNode("u8"),
+                            prefixedCountNode(numberTypeNode("u8"))
+                        ),
+                        docs: [
+                            "SmallVec<u8, u8> — relying party ID (max 32 bytes, no quote chars).",
+                        ],
+                    }),
+                    structFieldTypeNode({
+                        name: "publicKey",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 33),
+                        docs: [
+                            "Compressed P256 public key: [y_parity(1) | x(32)].",
+                        ],
+                    }),
+                    structFieldTypeNode({
+                        name: "clientDataJsonReconstructionParams",
+                        type: definedTypeLinkNode("clientDataJsonReconstructionParams"),
+                    }),
+                ]),
+                docs: [
+                    "P256 WebAuthn initialization data.",
+                    "Borsh-serialized inside the initializationData SmallVec bytes.",
+                ],
+            }),
+
+            // P256RawVerificationData — what goes inside extraVerificationData bytes
+            definedTypeNode({
+                name: "p256RawVerificationData",
+                type: structTypeNode([
+                    structFieldTypeNode({
+                        name: "publicKey",
+                        type: fixedSizeTypeNode(bytesTypeNode(), 33),
+                        docs: ["Compressed P256 public key: [y_parity(1) | x(32)]."],
+                    }),
+                    structFieldTypeNode({
+                        name: "clientDataJsonReconstructionParams",
+                        type: definedTypeLinkNode("clientDataJsonReconstructionParams"),
+                    }),
+                ]),
+                docs: [
+                    "P256 WebAuthn verification data.",
+                    "Borsh-serialized inside the extraVerificationData / verificationData SmallVec bytes.",
+                ],
+            }),
+        ],
+
+        // ====================================================================
+        // Errors
+        // ====================================================================
+        errors: [
+            // Nonce errors (0-4)
+            errorNode({ name: "invalidSlothashIndex", code: 0, message: "Invalid slothash index" }),
+            errorNode({ name: "invalidTruncatedSlot", code: 1, message: "Invalid truncated slot" }),
+            errorNode({ name: "expiredSlothash", code: 2, message: "Expired slothash" }),
+            errorNode({ name: "missingNonceSignature", code: 3, message: "Missing nonce signature" }),
+            errorNode({ name: "cpiNotAllowed", code: 4, message: "CPI not allowed" }),
+
+            // Introspection errors (5-9)
+            errorNode({ name: "invalidInstructionSysvarAccount", code: 5, message: "Invalid instruction sysvar account" }),
+            errorNode({ name: "invalidPrecompileId", code: 6, message: "Invalid precompile id" }),
+            errorNode({ name: "invalidNumPrecompileSignatures", code: 7, message: "Invalid number of precompile signatures" }),
+            errorNode({ name: "invalidSignatureIndex", code: 8, message: "Invalid signature index" }),
+            errorNode({ name: "invalidSignatureOffset", code: 9, message: "Invalid signature offset" }),
+
+            // Serialization errors (10-13)
+            errorNode({ name: "errorInitializingHeader", code: 10, message: "Error initializing header" }),
+            errorNode({ name: "errorDeserializingHeader", code: 11, message: "Error deserializing header" }),
+            errorNode({ name: "errorInitializingAccountData", code: 12, message: "Error initializing account data" }),
+            errorNode({ name: "errorDeserializingAccountData", code: 13, message: "Error deserializing account data" }),
+
+            // Execution errors (14-19)
+            errorNode({ name: "invalidExtraVerificationDataArgs", code: 14, message: "Invalid extra verification data args" }),
+            errorNode({ name: "invalidExecutionArgs", code: 15, message: "Invalid execution args" }),
+            errorNode({ name: "sessionSignerNotASigner", code: 16, message: "Session signer is not a signer" }),
+            errorNode({ name: "invalidSessionKey", code: 17, message: "Invalid session key" }),
+            errorNode({ name: "sessionKeyExpired", code: 18, message: "Session key expired" }),
+            errorNode({ name: "invalidSessionKeyExpiration", code: 19, message: "Invalid session key expiration" }),
+
+            // Signature scheme errors (20)
+            errorNode({ name: "invalidSignatureScheme", code: 20, message: "Invalid signature scheme" }),
+
+            // Signer execution errors (21-22)
+            errorNode({ name: "invalidSignerExecutionScheme", code: 21, message: "Invalid signer execution scheme" }),
+            errorNode({ name: "signerExecutionAccountNotASigner", code: 22, message: "Signer execution account is not a signer" }),
+
+            // P256 WebAuthn errors (23-31)
+            errorNode({ name: "p256RelyingPartTooLong", code: 23, message: "Relying party ID too long. Max length is 32 bytes" }),
+            errorNode({ name: "p256RelyingPartIncludeQuotes", code: 24, message: "Relying party does not get to include quotes" }),
+            errorNode({ name: "p256RelyingPartyMismatch", code: 25, message: "Relying party mismatch" }),
+            errorNode({ name: "p256ClientDataHashMismatch", code: 26, message: "Client data hash mismatch" }),
+            errorNode({ name: "p256AccountNotWritable", code: 27, message: "Account is not writable" }),
+            errorNode({ name: "p256InvalidAlgorithm", code: 28, message: "Invalid passkey Algorithm" }),
+            errorNode({ name: "p256InvalidPublicKeyEncoding", code: 29, message: "Invalid public key encoding" }),
+            errorNode({ name: "p256PublicKeyMismatch", code: 30, message: "Public key mismatch" }),
+            errorNode({ name: "p256UserNotVerified", code: 31, message: "User not verified" }),
+            errorNode({ name: "p256UserNotPresent", code: 32, message: "User not present" }),
+        ],
+
+        // ====================================================================
+        // PDAs
+        // ====================================================================
+        pdas: [
+            pdaNode({
+                name: "externallySignedAccount",
+                seeds: [
+                    constantPdaSeedNodeFromString("utf8", "passkey"),
+                    variablePdaSeedNode(
+                        "hashedPublicKey",
+                        fixedSizeTypeNode(bytesTypeNode(), 32),
+                        [
+                            "SHA-256 hash of the compressed P256 public key (33 bytes -> 32 bytes).",
+                            "Hash is required because PDA seeds are limited to 32 bytes each.",
+                        ]
+                    ),
+                ],
+            }),
+            pdaNode({
+                name: "executionAccount",
+                seeds: [
+                    variablePdaSeedNode(
+                        "externallySignedAccountKey",
+                        publicKeyTypeNode(),
+                        ["The public key of the parent externally-signed account."]
+                    ),
+                    constantPdaSeedNodeFromString("utf8", "execution_account"),
+                ],
+            }),
+        ],
+    })
+);
+
+// ============================================================================
+// Export / Write IDL
+// ============================================================================
+const codama = createFromRoot(root);
+
+// Write the IDL JSON to disk for reference
+const idlJson = JSON.stringify(root, null, 2);
+const outputPath = path.join(__dirname, "..", "idl.json");
+fs.writeFileSync(outputPath, idlJson);
+console.log(`Codama IDL written to ${outputPath}`);
+
+// Export for programmatic use
+export { root, codama };

--- a/idl.json
+++ b/idl.json
@@ -1,0 +1,1443 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.6.0",
+  "program": {
+    "kind": "programNode",
+    "name": "externalSignatureProgram",
+    "publicKey": "ExtSgUPtP3JyKUysFw2S5fpL5fWfUPzGUQLd2bTwftXN",
+    "version": "0.1.0",
+    "origin": "native",
+    "docs": [],
+    "accounts": [
+      {
+        "kind": "accountNode",
+        "name": "p256WebauthnAccount",
+        "size": 152,
+        "docs": [],
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "version",
+              "defaultValueStrategy": "omitted",
+              "docs": [],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "defaultValue": {
+                "kind": "numberValueNode",
+                "number": 1
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "scheme",
+              "defaultValueStrategy": "omitted",
+              "docs": [],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "defaultValue": {
+                "kind": "numberValueNode",
+                "number": 0
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "reserved",
+              "defaultValueStrategy": "omitted",
+              "docs": [],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 2,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              },
+              "defaultValue": {
+                "kind": "numberValueNode",
+                "number": 0
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "rpIdLen",
+              "docs": [],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "rpId",
+              "docs": [
+                "Relying party ID, padded to 32 bytes"
+              ],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 32,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "rpIdHash",
+              "docs": [
+                "SHA-256 hash of the relying party ID"
+              ],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 32,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "publicKeyX",
+              "docs": [
+                "X coordinate of the P256 public key"
+              ],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 32,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "publicKeyYParity",
+              "docs": [
+                "Y parity byte (0x02 or 0x03)"
+              ],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "padding",
+              "defaultValueStrategy": "omitted",
+              "docs": [],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 2,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              },
+              "defaultValue": {
+                "kind": "numberValueNode",
+                "number": 0
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "sessionKeyPublicKey",
+              "docs": [
+                "Ed25519 public key of the session key (zeroed if none)"
+              ],
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "sessionKeyExpiration",
+              "docs": [
+                "Unix timestamp when the session key expires"
+              ],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "counter",
+              "docs": [
+                "WebAuthn signature counter for replay protection.",
+                "Must be monotonically increasing."
+              ],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              }
+            }
+          ]
+        },
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "value": {
+                "kind": "numberValueNode",
+                "number": 1
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "initializeExternalAccount",
+        "docs": [
+          "Initializes a new externally-signed account with WebAuthn/P256 credentials.",
+          "A secp256r1 precompile instruction must precede this instruction in the transaction."
+        ],
+        "optionalAccountStrategy": "omitted",
+        "accounts": [
+          {
+            "kind": "instructionAccountNode",
+            "name": "externallySignedAccount",
+            "isWritable": true,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "The PDA to be created, derived from hash of compressed public key."
+            ]
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "rentPayer",
+            "isWritable": true,
+            "isSigner": true,
+            "isOptional": false,
+            "docs": [
+              "The account paying for rent and transaction fees."
+            ]
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "instructionsSysvar",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "Instructions sysvar for precompile signature introspection."
+            ],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "Sysvar1nstructions1111111111111111111111111",
+              "identifier": "splInstructions"
+            }
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "slotHashesSysvar",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "SlotHashes sysvar for nonce validation."
+            ],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarS1otHashes111111111111111111111111111",
+              "identifier": "splSlotHashes"
+            }
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "systemProgram",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "System Program for account creation."
+            ],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "11111111111111111111111111111111",
+              "identifier": "systemProgram"
+            }
+          }
+        ],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 0
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "slothash",
+            "docs": [
+              "Truncated slot (last 3 digits of slot height, mod 1000).",
+              "Used as nonce — must match a recent slot hash (within 150 slots)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "signatureScheme",
+            "docs": [
+              "The signature scheme (currently only P256Webauthn = 0)."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "signatureScheme"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "initializationData",
+            "docs": [
+              "Scheme-specific initialization data as SmallVec<u8, u8>.",
+              "For P256Webauthn: borsh-serialized P256RawInitializationData",
+              "(rp_id: SmallVec<u8,u8>, public_key: [u8;33],",
+              " client_data_json_reconstruction_params: ClientDataJsonReconstructionParams)."
+            ],
+            "type": {
+              "kind": "sizePrefixTypeNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "sessionKey",
+            "docs": [
+              "Optional session key. If provided, its expiration must not exceed",
+              "3 months from the current Clock timestamp."
+            ],
+            "type": {
+              "kind": "optionTypeNode",
+              "fixed": false,
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "sessionKey"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "value": {
+                "kind": "numberValueNode",
+                "number": 0
+              }
+            }
+          }
+        ]
+      },
+      {
+        "kind": "instructionNode",
+        "name": "executeInstructions",
+        "docs": [
+          "Executes a batch of compiled instructions authenticated by a direct P256 signature.",
+          "A secp256r1 precompile instruction must precede this instruction in the transaction.",
+          "Includes reentrancy protection (cannot CPI back to this program)."
+        ],
+        "optionalAccountStrategy": "omitted",
+        "accounts": [
+          {
+            "kind": "instructionAccountNode",
+            "name": "externallySignedAccount",
+            "isWritable": true,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "The externally-signed PDA that authorizes the instructions."
+            ]
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "instructionsSysvar",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "Instructions sysvar for precompile signature verification."
+            ],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "Sysvar1nstructions1111111111111111111111111",
+              "identifier": "splInstructions"
+            }
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "slotHashesSysvar",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "SlotHashes sysvar for nonce validation."
+            ],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarS1otHashes111111111111111111111111111",
+              "identifier": "splSlotHashes"
+            }
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "nonceSigner",
+            "isWritable": false,
+            "isSigner": true,
+            "isOptional": false,
+            "docs": [
+              "The signer providing the nonce signature for replay protection."
+            ]
+          }
+        ],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 1
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "signatureScheme",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "signatureScheme"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "signerExecutionScheme",
+            "docs": [
+              "Determines which account signs CPI calls:",
+              "ExecutionAccount (0) = derived PDA, ExternalAccount (1) = the ESA itself."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "signerExecutionScheme"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "slothash",
+            "docs": [
+              "Truncated slot for nonce validation (mod 1000)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "extraVerificationData",
+            "docs": [
+              "Scheme-specific verification data as SmallVec<u8, u8>.",
+              "For P256Webauthn: borsh-serialized P256RawVerificationData",
+              "(public_key: [u8;33], client_data_json_reconstruction_params)."
+            ],
+            "type": {
+              "kind": "sizePrefixTypeNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "instructions",
+            "docs": [
+              "SmallVec<u8, CompiledInstruction> — compiled instructions to execute via CPI.",
+              "Account indices reference the remaining accounts."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "compiledInstruction"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ],
+        "remainingAccounts": [
+          {
+            "kind": "instructionRemainingAccountsNode",
+            "docs": [],
+            "value": {
+              "isOptional": false,
+              "isSigner": false,
+              "isWritable": false,
+              "docs": [
+                "Accounts referenced by the compiled instructions.",
+                "The execution account (derived PDA or ESA itself, based on",
+                "signerExecutionScheme) should be included here when needed."
+              ]
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "value": {
+                "kind": "numberValueNode",
+                "number": 1
+              }
+            }
+          }
+        ]
+      },
+      {
+        "kind": "instructionNode",
+        "name": "refreshSessionKey",
+        "docs": [
+          "Refreshes the session key on an externally-signed account.",
+          "Requires a fresh P256 signature. The new expiration is calculated as",
+          "Clock::unix_timestamp + session_key.expiration (treated as a duration)."
+        ],
+        "optionalAccountStrategy": "omitted",
+        "accounts": [
+          {
+            "kind": "instructionAccountNode",
+            "name": "externallySignedAccount",
+            "isWritable": true,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "The externally-signed PDA whose session key is being refreshed."
+            ]
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "instructionsSysvar",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "Sysvar1nstructions1111111111111111111111111",
+              "identifier": "splInstructions"
+            }
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "slotHashesSysvar",
+            "isWritable": false,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [],
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarS1otHashes111111111111111111111111111",
+              "identifier": "splSlotHashes"
+            }
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "nonceSigner",
+            "isWritable": false,
+            "isSigner": true,
+            "isOptional": false,
+            "docs": [
+              "The signer providing the nonce signature."
+            ]
+          }
+        ],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 2
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "slothash",
+            "docs": [
+              "Truncated slot for nonce validation (mod 1000)."
+            ],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u16",
+              "endian": "le"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "signatureScheme",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "signatureScheme"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "verificationData",
+            "docs": [
+              "Scheme-specific verification data as SmallVec<u8, u8>.",
+              "For P256Webauthn: borsh-serialized P256RawVerificationData."
+            ],
+            "type": {
+              "kind": "sizePrefixTypeNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "sessionKey",
+            "docs": [
+              "The new session key. The expiration field is treated as a",
+              "duration (seconds) — the program adds it to Clock::unix_timestamp."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "sessionKey"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "value": {
+                "kind": "numberValueNode",
+                "number": 2
+              }
+            }
+          }
+        ]
+      },
+      {
+        "kind": "instructionNode",
+        "name": "executeInstructionsSessioned",
+        "docs": [
+          "Executes compiled instructions using an active session key.",
+          "No precompile signature required — the session key signer authorizes execution.",
+          "Validates session key against the account and checks expiration.",
+          "Includes reentrancy protection."
+        ],
+        "optionalAccountStrategy": "omitted",
+        "accounts": [
+          {
+            "kind": "instructionAccountNode",
+            "name": "externallySignedAccount",
+            "isWritable": true,
+            "isSigner": false,
+            "isOptional": false,
+            "docs": [
+              "The externally-signed PDA that authorizes the instructions."
+            ]
+          },
+          {
+            "kind": "instructionAccountNode",
+            "name": "sessionSigner",
+            "isWritable": false,
+            "isSigner": true,
+            "isOptional": false,
+            "docs": [
+              "The session key signer — must match the key stored on the account."
+            ]
+          }
+        ],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "defaultValueStrategy": "omitted",
+            "docs": [],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "defaultValue": {
+              "kind": "numberValueNode",
+              "number": 3
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "signatureScheme",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "signatureScheme"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "signerExecutionScheme",
+            "docs": [
+              "ExecutionAccount (0) = derived PDA signs,",
+              "ExternalAccount (1) = ESA itself signs."
+            ],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "signerExecutionScheme"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "instructions",
+            "docs": [
+              "SmallVec<u8, CompiledInstruction> — compiled instructions to execute."
+            ],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "definedTypeLinkNode",
+                "name": "compiledInstruction"
+              },
+              "count": {
+                "kind": "prefixedCountNode",
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              }
+            }
+          }
+        ],
+        "remainingAccounts": [
+          {
+            "kind": "instructionRemainingAccountsNode",
+            "docs": [],
+            "value": {
+              "isOptional": false,
+              "isSigner": false,
+              "isWritable": false,
+              "docs": [
+                "Accounts referenced by the compiled instructions."
+              ]
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              },
+              "value": {
+                "kind": "numberValueNode",
+                "number": 3
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "definedTypes": [
+      {
+        "kind": "definedTypeNode",
+        "name": "signatureScheme",
+        "docs": [
+          "The signature verification scheme.",
+          "Currently only P256Webauthn (0) is supported."
+        ],
+        "type": {
+          "kind": "enumTypeNode",
+          "variants": [
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "p256Webauthn"
+            }
+          ],
+          "size": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "signerExecutionScheme",
+        "docs": [
+          "Determines which account signs CPI calls.",
+          "ExecutionAccount: a derived PDA (ESA key + 'execution_account').",
+          "ExternalAccount: the externally-signed account itself."
+        ],
+        "type": {
+          "kind": "enumTypeNode",
+          "variants": [
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "executionAccount"
+            },
+            {
+              "kind": "enumEmptyVariantTypeNode",
+              "name": "externalAccount"
+            }
+          ],
+          "size": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "sessionKey",
+        "docs": [
+          "An ephemeral session key with an expiration."
+        ],
+        "type": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "key",
+              "docs": [
+                "Ed25519 public key of the session key."
+              ],
+              "type": {
+                "kind": "publicKeyTypeNode"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "expiration",
+              "docs": [
+                "For initialization/refresh: duration in seconds to add to current timestamp.",
+                "On-chain: absolute unix timestamp of expiration.",
+                "Max 3 months (7,776,000 seconds) from current time."
+              ],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u64",
+                "endian": "le"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "compiledInstruction",
+        "docs": [
+          "A compiled instruction that references accounts by index into the",
+          "remaining accounts array. Uses SmallVec (u8/u16 length prefixes)."
+        ],
+        "type": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "programIdIndex",
+              "docs": [
+                "Index into the remaining accounts for the program to invoke."
+              ],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "accountsIndices",
+              "docs": [
+                "SmallVec<u8, u8> — indices into remaining accounts for this instruction."
+              ],
+              "type": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "u8",
+                    "endian": "le"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "data",
+              "docs": [
+                "SmallVec<u16, u8> — the instruction data (u16 length prefix)."
+              ],
+              "type": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "u16",
+                    "endian": "le"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "clientDataJsonReconstructionParams",
+        "docs": [
+          "Minimal representation for reconstructing the WebAuthn clientDataJSON.",
+          "Used in both initialization and verification data."
+        ],
+        "type": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "typeAndFlags",
+              "docs": [
+                "Packed byte: high nibble = auth type (0x00=create, 0x10=get),",
+                "low nibble = flags (0x01=crossOrigin, 0x02=http, 0x04=googleExtra)."
+              ],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "port",
+              "docs": [
+                "Optional port number for the origin URL."
+              ],
+              "type": {
+                "kind": "optionTypeNode",
+                "fixed": false,
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u16",
+                  "endian": "le"
+                },
+                "prefix": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "p256RawInitializationData",
+        "docs": [
+          "P256 WebAuthn initialization data.",
+          "Borsh-serialized inside the initializationData SmallVec bytes."
+        ],
+        "type": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "rpId",
+              "docs": [
+                "SmallVec<u8, u8> — relying party ID (max 32 bytes, no quote chars)."
+              ],
+              "type": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                },
+                "count": {
+                  "kind": "prefixedCountNode",
+                  "prefix": {
+                    "kind": "numberTypeNode",
+                    "format": "u8",
+                    "endian": "le"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "publicKey",
+              "docs": [
+                "Compressed P256 public key: [y_parity(1) | x(32)]."
+              ],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 33,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "clientDataJsonReconstructionParams",
+              "docs": [],
+              "type": {
+                "kind": "definedTypeLinkNode",
+                "name": "clientDataJsonReconstructionParams"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "p256RawVerificationData",
+        "docs": [
+          "P256 WebAuthn verification data.",
+          "Borsh-serialized inside the extraVerificationData / verificationData SmallVec bytes."
+        ],
+        "type": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "publicKey",
+              "docs": [
+                "Compressed P256 public key: [y_parity(1) | x(32)]."
+              ],
+              "type": {
+                "kind": "fixedSizeTypeNode",
+                "size": 33,
+                "type": {
+                  "kind": "bytesTypeNode"
+                }
+              }
+            },
+            {
+              "kind": "structFieldTypeNode",
+              "name": "clientDataJsonReconstructionParams",
+              "docs": [],
+              "type": {
+                "kind": "definedTypeLinkNode",
+                "name": "clientDataJsonReconstructionParams"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "pdas": [
+      {
+        "kind": "pdaNode",
+        "name": "externallySignedAccount",
+        "docs": [],
+        "seeds": [
+          {
+            "kind": "constantPdaSeedNode",
+            "type": {
+              "kind": "stringTypeNode",
+              "encoding": "utf8"
+            },
+            "value": {
+              "kind": "stringValueNode",
+              "string": "passkey"
+            }
+          },
+          {
+            "kind": "variablePdaSeedNode",
+            "name": "hashedPublicKey",
+            "docs": [
+              "SHA-256 hash of the compressed P256 public key (33 bytes -> 32 bytes).",
+              "Hash is required because PDA seeds are limited to 32 bytes each."
+            ],
+            "type": {
+              "kind": "fixedSizeTypeNode",
+              "size": 32,
+              "type": {
+                "kind": "bytesTypeNode"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "kind": "pdaNode",
+        "name": "executionAccount",
+        "docs": [],
+        "seeds": [
+          {
+            "kind": "variablePdaSeedNode",
+            "name": "externallySignedAccountKey",
+            "docs": [
+              "The public key of the parent externally-signed account."
+            ],
+            "type": {
+              "kind": "publicKeyTypeNode"
+            }
+          },
+          {
+            "kind": "constantPdaSeedNode",
+            "type": {
+              "kind": "stringTypeNode",
+              "encoding": "utf8"
+            },
+            "value": {
+              "kind": "stringValueNode",
+              "string": "execution_account"
+            }
+          }
+        ]
+      }
+    ],
+    "events": [],
+    "errors": [
+      {
+        "kind": "errorNode",
+        "name": "invalidSlothashIndex",
+        "code": 0,
+        "message": "Invalid slothash index",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidTruncatedSlot",
+        "code": 1,
+        "message": "Invalid truncated slot",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "expiredSlothash",
+        "code": 2,
+        "message": "Expired slothash",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "missingNonceSignature",
+        "code": 3,
+        "message": "Missing nonce signature",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "cpiNotAllowed",
+        "code": 4,
+        "message": "CPI not allowed",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidInstructionSysvarAccount",
+        "code": 5,
+        "message": "Invalid instruction sysvar account",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidPrecompileId",
+        "code": 6,
+        "message": "Invalid precompile id",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidNumPrecompileSignatures",
+        "code": 7,
+        "message": "Invalid number of precompile signatures",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidSignatureIndex",
+        "code": 8,
+        "message": "Invalid signature index",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidSignatureOffset",
+        "code": 9,
+        "message": "Invalid signature offset",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "errorInitializingHeader",
+        "code": 10,
+        "message": "Error initializing header",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "errorDeserializingHeader",
+        "code": 11,
+        "message": "Error deserializing header",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "errorInitializingAccountData",
+        "code": 12,
+        "message": "Error initializing account data",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "errorDeserializingAccountData",
+        "code": 13,
+        "message": "Error deserializing account data",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidExtraVerificationDataArgs",
+        "code": 14,
+        "message": "Invalid extra verification data args",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidExecutionArgs",
+        "code": 15,
+        "message": "Invalid execution args",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "sessionSignerNotASigner",
+        "code": 16,
+        "message": "Session signer is not a signer",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidSessionKey",
+        "code": 17,
+        "message": "Invalid session key",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "sessionKeyExpired",
+        "code": 18,
+        "message": "Session key expired",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidSessionKeyExpiration",
+        "code": 19,
+        "message": "Invalid session key expiration",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidSignatureScheme",
+        "code": 20,
+        "message": "Invalid signature scheme",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "invalidSignerExecutionScheme",
+        "code": 21,
+        "message": "Invalid signer execution scheme",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "signerExecutionAccountNotASigner",
+        "code": 22,
+        "message": "Signer execution account is not a signer",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256RelyingPartTooLong",
+        "code": 23,
+        "message": "Relying party ID too long. Max length is 32 bytes",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256RelyingPartIncludeQuotes",
+        "code": 24,
+        "message": "Relying party does not get to include quotes",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256RelyingPartyMismatch",
+        "code": 25,
+        "message": "Relying party mismatch",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256ClientDataHashMismatch",
+        "code": 26,
+        "message": "Client data hash mismatch",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256AccountNotWritable",
+        "code": 27,
+        "message": "Account is not writable",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256InvalidAlgorithm",
+        "code": 28,
+        "message": "Invalid passkey Algorithm",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256InvalidPublicKeyEncoding",
+        "code": 29,
+        "message": "Invalid public key encoding",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256PublicKeyMismatch",
+        "code": 30,
+        "message": "Public key mismatch",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256UserNotVerified",
+        "code": 31,
+        "message": "User not verified",
+        "docs": []
+      },
+      {
+        "kind": "errorNode",
+        "name": "p256UserNotPresent",
+        "code": 32,
+        "message": "User not present",
+        "docs": []
+      }
+    ]
+  },
+  "additionalPrograms": []
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "external-signature-program",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "codama": "^1.6.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,625 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      codama:
+        specifier: ^1.6.0
+        version: 1.6.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@codama/cli@1.5.1':
+    resolution: {integrity: sha512-Cn9SokOi0IpixbdW1Aus61Qt0GCJhWE/+q1OdcvRBAQ4V0NacCpdf7N9aF9HR/H7AD+LWJa3JtK7pEs69ywM6Q==}
+    hasBin: true
+
+  '@codama/errors@1.6.0':
+    resolution: {integrity: sha512-Evj9wO5lqvxvbjxG856ITY5lhRN7SqoYfRX4tMMBjs8J/kT+pKQ8qL0hz9OynOOv/5mWn9Q/sPCNzQ6CUscibQ==}
+    hasBin: true
+
+  '@codama/node-types@1.6.0':
+    resolution: {integrity: sha512-atIJW2/3MjPYey0bNlE86W9Gvq9aq8bud7zT7PMyyhj98mbmLqPwT4wclPdbFua0fROLkq17z3bXaaJy5FqSEw==}
+
+  '@codama/nodes@1.6.0':
+    resolution: {integrity: sha512-F6Hy3REfl+Ih5R3jldPqEMjFqaPj871iBWX/LV0EtNK0xn7E4DG/3XCK4wlbHrOT9Z1NsiA70e0M1uChzmIrsw==}
+
+  '@codama/validators@1.6.0':
+    resolution: {integrity: sha512-QlLIQt6EpZ7sQvVOz8NFKtrzWLAwYzle0tet2Q0DDU8+4LO654lj+oAwjXzY3eAfTesqBqOgMCPtQe0EpGWk3g==}
+
+  '@codama/visitors-core@1.6.0':
+    resolution: {integrity: sha512-YG0rExvLbBCDAzXnZX6Imu4KwDoZrZz9NF232/nzs9Dr8uQuEWJ81x4VR9UxIcANHcF0+XwJzHamSwhZroAtjQ==}
+
+  '@codama/visitors@1.6.0':
+    resolution: {integrity: sha512-11/adC2WiH3+iMWluXkb+ae46sjoDm2xztI+CBEeIcBQd6mm4iuJTTRS0yrGfDwAJE1XzI/nc2MrR0Pvn+Rvvw==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  codama@1.6.0:
+    resolution: {integrity: sha512-JKydzwNYJkGjkZ98ipehd3hJksLQU6nYS7x0GPjOwD0wih+xP8q7WCKgleN8LM2sRuC75rfpr3uXLXSpQpBYKA==}
+    hasBin: true
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+snapshots:
+
+  '@codama/cli@1.5.1':
+    dependencies:
+      '@codama/nodes': 1.6.0
+      '@codama/visitors': 1.6.0
+      '@codama/visitors-core': 1.6.0
+      commander: 14.0.3
+      picocolors: 1.1.1
+      prompts: 2.4.2
+
+  '@codama/errors@1.6.0':
+    dependencies:
+      '@codama/node-types': 1.6.0
+      commander: 14.0.3
+      picocolors: 1.1.1
+
+  '@codama/node-types@1.6.0': {}
+
+  '@codama/nodes@1.6.0':
+    dependencies:
+      '@codama/errors': 1.6.0
+      '@codama/node-types': 1.6.0
+
+  '@codama/validators@1.6.0':
+    dependencies:
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/visitors-core': 1.6.0
+
+  '@codama/visitors-core@1.6.0':
+    dependencies:
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      json-stable-stringify: 1.3.0
+
+  '@codama/visitors@1.6.0':
+    dependencies:
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/visitors-core': 1.6.0
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  codama@1.6.0:
+    dependencies:
+      '@codama/cli': 1.5.1
+      '@codama/errors': 1.6.0
+      '@codama/nodes': 1.6.0
+      '@codama/validators': 1.6.0
+      '@codama/visitors': 1.6.0
+
+  commander@14.0.3: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  gopd@1.2.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  isarray@2.0.5: {}
+
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
+  jsonify@0.0.1: {}
+
+  kleur@3.0.3: {}
+
+  math-intrinsics@1.1.0: {}
+
+  object-keys@1.1.1: {}
+
+  picocolors@1.1.1: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
+  resolve-pkg-maps@1.0.0: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  sisteransi@1.0.5: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@6.0.3: {}
+
+  undici-types@7.19.2: {}


### PR DESCRIPTION
## Summary

- Adds `codama/codama.ts` defining the full program IDL using Codama's TypeScript node API
- Generates `idl.json` (Codama `rootNode` format) — natively supported by Solana Explorer
- Covers all 4 instructions, the P256 WebAuthn account layout, 7 defined types, 33 errors, and 2 PDAs

## What's included

| Component | Details |
|---|---|
| **Account** | `p256WebauthnAccount` (152 bytes) — matches `#[repr(C)]` layout exactly |
| **Instructions** | `initializeExternalAccount` (0), `executeInstructions` (1), `refreshSessionKey` (2), `executeInstructionsSessioned` (3) |
| **Types** | `signatureScheme`, `signerExecutionScheme`, `sessionKey`, `compiledInstruction`, `clientDataJsonReconstructionParams`, `p256RawInitializationData`, `p256RawVerificationData` |
| **Errors** | All 33 variants with correct `#[repr(u32)]` codes |
| **PDAs** | `externallySignedAccount` (`"passkey"` + hashed pubkey), `executionAccount` (ESA key + `"execution_account"`) |

## Usage

Regenerate the IDL:
```bash
pnpm install
pnpx tsx codama/codama.ts
```

Upload to Solana Explorer via program-metadata:
```bash
npx @solana-program/program-metadata@latest write idl ExtSgUPtP3JyKUysFw2S5fpL5fWfUPzGUQLd2bTwftXN ./idl.json
```

## Verification

- Account/arg order cross-checked against Rust destructuring patterns
- Field sizes verified against `#[repr(C)]` layout (152 bytes)
- Error codes verified sequential (0-32) matching enum order
- PDA seeds match `try_find_program_address` calls
- Simulated Solana Explorer's `useFormatCodamaIdl` parsing — all nodes parse correctly