### PR TITLE
feat: nordpass support

### DIFF
--- a/codama/codama.ts
+++ b/codama/codama.ts
@@ -648,7 +648,7 @@ const root = rootNode(
                         type: numberTypeNode("u8"),
                         docs: [
                             "Packed byte: high nibble = auth type (0x00=create, 0x10=get),",
-                            "low nibble = flags (0x01=crossOrigin, 0x02=http, 0x04=googleExtra).",
+                            "low nibble = flags (0x01=crossOrigin, 0x02=http, 0x04=googleExtra, 0x08=omitCrossOrigin).",
                         ],
                     }),
                     structFieldTypeNode({

--- a/idl.json
+++ b/idl.json
@@ -1013,7 +1013,7 @@
               "name": "typeAndFlags",
               "docs": [
                 "Packed byte: high nibble = auth type (0x00=create, 0x10=get),",
-                "low nibble = flags (0x01=crossOrigin, 0x02=http, 0x04=googleExtra)."
+                "low nibble = flags (0x01=crossOrigin, 0x02=http, 0x04=googleExtra, 0x08=omitCrossOrigin)."
               ],
               "type": {
                 "kind": "numberTypeNode",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1036 @@
+{
+  "name": "external-signature-program",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "external-signature-program",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "codama": "^1.6.0",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@codama/cli": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@codama/cli/-/cli-1.5.1.tgz",
+      "integrity": "sha512-Cn9SokOi0IpixbdW1Aus61Qt0GCJhWE/+q1OdcvRBAQ4V0NacCpdf7N9aF9HR/H7AD+LWJa3JtK7pEs69ywM6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/nodes": "1.6.0",
+        "@codama/visitors": "1.6.0",
+        "@codama/visitors-core": "1.6.0",
+        "commander": "^14.0.2",
+        "picocolors": "^1.1.1",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "codama": "bin/cli.cjs"
+      }
+    },
+    "node_modules/@codama/errors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@codama/errors/-/errors-1.6.0.tgz",
+      "integrity": "sha512-Evj9wO5lqvxvbjxG856ITY5lhRN7SqoYfRX4tMMBjs8J/kT+pKQ8qL0hz9OynOOv/5mWn9Q/sPCNzQ6CUscibQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/node-types": "1.6.0",
+        "commander": "^14.0.2",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "errors": "bin/cli.cjs"
+      }
+    },
+    "node_modules/@codama/node-types": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@codama/node-types/-/node-types-1.6.0.tgz",
+      "integrity": "sha512-atIJW2/3MjPYey0bNlE86W9Gvq9aq8bud7zT7PMyyhj98mbmLqPwT4wclPdbFua0fROLkq17z3bXaaJy5FqSEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@codama/nodes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@codama/nodes/-/nodes-1.6.0.tgz",
+      "integrity": "sha512-F6Hy3REfl+Ih5R3jldPqEMjFqaPj871iBWX/LV0EtNK0xn7E4DG/3XCK4wlbHrOT9Z1NsiA70e0M1uChzmIrsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/errors": "1.6.0",
+        "@codama/node-types": "1.6.0"
+      }
+    },
+    "node_modules/@codama/validators": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@codama/validators/-/validators-1.6.0.tgz",
+      "integrity": "sha512-QlLIQt6EpZ7sQvVOz8NFKtrzWLAwYzle0tet2Q0DDU8+4LO654lj+oAwjXzY3eAfTesqBqOgMCPtQe0EpGWk3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/errors": "1.6.0",
+        "@codama/nodes": "1.6.0",
+        "@codama/visitors-core": "1.6.0"
+      }
+    },
+    "node_modules/@codama/visitors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@codama/visitors/-/visitors-1.6.0.tgz",
+      "integrity": "sha512-11/adC2WiH3+iMWluXkb+ae46sjoDm2xztI+CBEeIcBQd6mm4iuJTTRS0yrGfDwAJE1XzI/nc2MrR0Pvn+Rvvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/errors": "1.6.0",
+        "@codama/nodes": "1.6.0",
+        "@codama/visitors-core": "1.6.0"
+      }
+    },
+    "node_modules/@codama/visitors-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@codama/visitors-core/-/visitors-core-1.6.0.tgz",
+      "integrity": "sha512-YG0rExvLbBCDAzXnZX6Imu4KwDoZrZz9NF232/nzs9Dr8uQuEWJ81x4VR9UxIcANHcF0+XwJzHamSwhZroAtjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/errors": "1.6.0",
+        "@codama/nodes": "1.6.0",
+        "json-stable-stringify": "^1.3.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/codama": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/codama/-/codama-1.6.0.tgz",
+      "integrity": "sha512-JKydzwNYJkGjkZ98ipehd3hJksLQU6nYS7x0GPjOwD0wih+xP8q7WCKgleN8LM2sRuC75rfpr3uXLXSpQpBYKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@codama/cli": "1.5.1",
+        "@codama/errors": "1.6.0",
+        "@codama/nodes": "1.6.0",
+        "@codama/validators": "1.6.0",
+        "@codama/visitors": "1.6.0"
+      },
+      "bin": {
+        "codama": "bin/cli.cjs"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdks/ts-sdk/src/clientDataJson.ts
+++ b/sdks/ts-sdk/src/clientDataJson.ts
@@ -11,6 +11,7 @@ const TYPE_GET = 0x10;
 const FLAG_CROSS_ORIGIN = 0x01;
 const FLAG_HTTP_ORIGIN = 0x02;
 const FLAG_GOOGLE_EXTRA = 0x04;
+const FLAG_OMIT_CROSS_ORIGIN = 0x08;
 export const GOOGLE_CLIENT_DATA_JSON_EXTRA_VALUE =
   "do not compare clientDataJSON against a template. See https://goo.gl/yabPex";
 
@@ -22,6 +23,7 @@ export function createClientDataJsonReconstructionParams(
   if (input.crossOrigin) typeAndFlags |= FLAG_CROSS_ORIGIN;
   if (input.isHttp) typeAndFlags |= FLAG_HTTP_ORIGIN;
   if (input.hasGoogleExtra) typeAndFlags |= FLAG_GOOGLE_EXTRA;
+  if (input.includeCrossOrigin === false) typeAndFlags |= FLAG_OMIT_CROSS_ORIGIN;
   return {
     typeAndFlags,
     port: input.port ?? null,
@@ -48,6 +50,7 @@ export function reconstructClientDataJson(
   const origin =
     params.port == null ? `${protocol}${rpId}` : `${protocol}${rpId}:${params.port}`;
   const crossOrigin = (params.typeAndFlags & FLAG_CROSS_ORIGIN) !== 0 ? "true" : "false";
+  const includeCrossOrigin = (params.typeAndFlags & FLAG_OMIT_CROSS_ORIGIN) === 0;
 
   const base = [
     "{\"type\":\"",
@@ -56,8 +59,8 @@ export function reconstructClientDataJson(
     challengeBase64Url,
     "\",\"origin\":\"",
     origin,
-    "\",\"crossOrigin\":",
-    crossOrigin,
+    "\"",
+    ...(includeCrossOrigin ? [",\"crossOrigin\":", crossOrigin] : []),
   ];
 
   const googleExtra =

--- a/sdks/ts-sdk/src/types.ts
+++ b/sdks/ts-sdk/src/types.ts
@@ -33,6 +33,7 @@ export interface ClientDataJsonReconstructionParams {
 export interface CreateClientDataJsonReconstructionParamsInput {
   authType: AuthType;
   crossOrigin: boolean;
+  includeCrossOrigin?: boolean;
   isHttp: boolean;
   hasGoogleExtra: boolean;
   port?: number | null;

--- a/sdks/ts-sdk/src/webauthn.ts
+++ b/sdks/ts-sdk/src/webauthn.ts
@@ -269,6 +269,7 @@ export function parseClientDataJsonReconstructionParams(
     return createClientDataJsonReconstructionParams({
       authType: json.type === "webauthn.create" ? AuthType.Create : AuthType.Get,
       crossOrigin: json.crossOrigin ?? false,
+      includeCrossOrigin: Object.prototype.hasOwnProperty.call(json, "crossOrigin"),
       isHttp: url.protocol === "http:",
       hasGoogleExtra: typeof json.other_keys_can_be_added_here === "string",
       port,

--- a/sdks/ts-sdk/tests/sdk.test.mjs
+++ b/sdks/ts-sdk/tests/sdk.test.mjs
@@ -14,6 +14,7 @@ import {
   createExecuteInstructionsChallenge,
   createInitializePasskeyChallenge,
   createSecp256r1Instruction,
+  reconstructClientDataJson,
   truncateSlot,
 } from "../dist/index.js";
 import { toLittleEndianU64 } from "../dist/bytes.js";
@@ -255,14 +256,33 @@ test("parseClientDataJsonReconstructionParams validates type and origin", () => 
       other_keys_can_be_added_here: GOOGLE_CLIENT_DATA_JSON_EXTRA_VALUE,
     }),
   );
+  const rawChallenge = Uint8Array.from("x", (char) => char.charCodeAt(0));
+  const encodedChallenge = "eA";
+  const withoutCrossOrigin = textEncoder.encode(
+    JSON.stringify({
+      type: "webauthn.create",
+      challenge: encodedChallenge,
+      origin: "https://example.com",
+    }),
+  );
 
   const createParams = parseClientDataJsonReconstructionParams(validCreate);
   const getParams = parseClientDataJsonReconstructionParams(validGet);
+  const withoutCrossOriginParams = parseClientDataJsonReconstructionParams(withoutCrossOrigin);
 
   assert.equal(createParams.typeAndFlags, 0x00);
   assert.equal(createParams.port, null);
   assert.equal(getParams.typeAndFlags, 0x17);
   assert.equal(getParams.port, 8080);
+  assert.equal(withoutCrossOriginParams.typeAndFlags, 0x08);
+  assert.deepEqual(
+    reconstructClientDataJson(
+      withoutCrossOriginParams,
+      "example.com",
+      rawChallenge,
+    ),
+    withoutCrossOrigin,
+  );
 
   const unknownType = textEncoder.encode(
     JSON.stringify({

--- a/src/utils/signatures/p256_webauthn/client_data_json.rs
+++ b/src/utils/signatures/p256_webauthn/client_data_json.rs
@@ -20,11 +20,32 @@ impl ClientDataJsonReconstructionParams {
     const FLAG_CROSS_ORIGIN: u8 = 0x01;
     const FLAG_HTTP_ORIGIN: u8 = 0x02; // If not set, assume https://
     const FLAG_GOOGLE_EXTRA: u8 = 0x04; // Extra field that chrome uses to make sure the clientDataJson is not compared to a template
+    const FLAG_OMIT_CROSS_ORIGIN: u8 = 0x08;
 
     /// Used to create the params (mostly for client side)
     pub fn new(
         auth_type: AuthType,
         cross_origin: bool,
+        is_http: bool,
+        has_google_extra: bool,
+        port: Option<u16>,
+    ) -> Self {
+        Self::new_with_optional_cross_origin(
+            auth_type,
+            cross_origin,
+            true,
+            is_http,
+            has_google_extra,
+            port,
+        )
+    }
+
+    /// Used when parsing browser-provided clientDataJSON, where field presence
+    /// matters for byte-for-byte reconstruction.
+    pub fn new_with_optional_cross_origin(
+        auth_type: AuthType,
+        cross_origin: bool,
+        has_cross_origin: bool,
         is_http: bool,
         has_google_extra: bool,
         port: Option<u16>,
@@ -42,6 +63,9 @@ impl ClientDataJsonReconstructionParams {
         }
         if has_google_extra {
             value |= Self::FLAG_GOOGLE_EXTRA;
+        }
+        if !has_cross_origin {
+            value |= Self::FLAG_OMIT_CROSS_ORIGIN;
         }
 
         Self {
@@ -72,6 +96,11 @@ impl ClientDataJsonReconstructionParams {
     /// Checks if the google extra field is set
     pub fn has_google_extra(&self) -> bool {
         self.type_and_flags & Self::FLAG_GOOGLE_EXTRA != 0
+    }
+
+    /// Checks if the crossOrigin field should be omitted.
+    pub fn omits_cross_origin(&self) -> bool {
+        self.type_and_flags & Self::FLAG_OMIT_CROSS_ORIGIN != 0
     }
 }
 
@@ -115,13 +144,6 @@ pub fn reconstruct_client_data_json(
     } else {
         format!("{}{}", prefix, std::str::from_utf8(rp_id).unwrap())
     };
-    // Create the cross origin string
-    let cross_origin = if params.is_cross_origin() {
-        "true"
-    } else {
-        "false"
-    };
-
     let mut json_bytes: Vec<u8> = Vec::with_capacity(256);
     json_bytes.extend_from_slice(b"{\"type\":\"");
     json_bytes.extend_from_slice(type_str.as_bytes());
@@ -129,8 +151,17 @@ pub fn reconstruct_client_data_json(
     json_bytes.extend_from_slice(challenge_b64url.as_bytes());
     json_bytes.extend_from_slice(b"\",\"origin\":\"");
     json_bytes.extend_from_slice(origin.as_bytes());
-    json_bytes.extend_from_slice(b"\",\"crossOrigin\":");
-    json_bytes.extend_from_slice(cross_origin.as_bytes());
+    json_bytes.extend_from_slice(b"\"");
+
+    if !params.omits_cross_origin() {
+        let cross_origin = if params.is_cross_origin() {
+            "true"
+        } else {
+            "false"
+        };
+        json_bytes.extend_from_slice(b",\"crossOrigin\":");
+        json_bytes.extend_from_slice(cross_origin.as_bytes());
+    }
 
     // Add Google's extra field if needed
     // Google note: One should not compare an unparsed clientDataJSON against a
@@ -234,6 +265,31 @@ mod tests {
             .unwrap();
 
         // Assert that the result matches the expected bytes
+        assert_eq!(result, expected_bytes);
+    }
+
+    #[test]
+    fn test_reconstruct_client_data_json_without_cross_origin() {
+        let params = ClientDataJsonReconstructionParams::new_with_optional_cross_origin(
+            AuthType::Create,
+            false,
+            false,
+            false,
+            false,
+            None,
+        );
+        let rp_id = "www.passkeys-debugger.io";
+        let challenge = general_purpose::URL_SAFE_NO_PAD
+            .decode("E7yasyYuzqwbUamcXXqz8PNJkZzJHYiZ8SWAkj37tco")
+            .unwrap();
+
+        let result = reconstruct_client_data_json(&params, rp_id.as_bytes(), &challenge);
+
+        let expected_base64 = "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiRTd5YXN5WXV6cXdiVWFtY1hYcXo4UE5Ka1p6SkhZaVo4U1dBa2ozN3RjbyIsIm9yaWdpbiI6Imh0dHBzOi8vd3d3LnBhc3NrZXlzLWRlYnVnZ2VyLmlvIn0";
+        let expected_bytes = general_purpose::URL_SAFE_NO_PAD
+            .decode(expected_base64)
+            .unwrap();
+
         assert_eq!(result, expected_bytes);
     }
 }

--- a/tests/p256/account_authentication.rs
+++ b/tests/p256/account_authentication.rs
@@ -189,6 +189,15 @@ mod test_authentication {
             "tests/p256/fixtures/ios-crossplatform/authentication.json",
         );
     }
+
+    #[test]
+    fn test_nordpass_authentication_without_cross_origin() {
+        test_authentication_from_fixture(
+            "tests/p256/fixtures/nordpass/creation.json",
+            "tests/p256/fixtures/nordpass/authentication.json",
+        );
+    }
+
     #[test]
     fn test_invalid_slothash() {
         test_authentication_invalid_slothash(

--- a/tests/p256/account_initialization.rs
+++ b/tests/p256/account_initialization.rs
@@ -1,10 +1,12 @@
 use crate::p256::utils::svm::get_valid_slothash;
 use crate::p256::utils::{
     initialization::initialize_passkey_account,
+    parser::parse_webauthn_fixture,
     svm::{create_and_send_svm_transaction, initialize_svm},
 };
 use solana_keypair::Keypair;
 use solana_signer::{EncodableKey, Signer};
+use std::fs;
 
 fn test_creation_from_fixture(path: &str) {
     let payer = Keypair::read_from_file(
@@ -44,5 +46,17 @@ mod test_initialization {
     #[test]
     fn test_one_password_creation() {
         test_creation_from_fixture("tests/p256/fixtures/one-password/creation.json");
+    }
+
+    #[test]
+    fn test_nordpass_creation_without_cross_origin() {
+        let path = "tests/p256/fixtures/nordpass/creation.json";
+        let json_data = fs::read_to_string(path).unwrap();
+        let webauthn_data = parse_webauthn_fixture(&json_data).unwrap();
+        assert!(webauthn_data
+            .client_data_json_reconstruction_params
+            .omits_cross_origin());
+
+        test_creation_from_fixture(path);
     }
 }

--- a/tests/p256/account_session_authentication.rs
+++ b/tests/p256/account_session_authentication.rs
@@ -112,6 +112,19 @@ mod test_authentication {
         );
     }
 
+    #[test]
+    fn test_nordpass_session_key_authentication_without_cross_origin() {
+        let payer = Keypair::read_from_file(
+            "tests/p256/keypairs/sinf1bu1CMQaMzeDoysAU7dAp2gs5j2V3vM9W5ZXAyB.json",
+        )
+        .unwrap();
+        let _ = test_session_authentication_from_fixture(
+            &payer,
+            "tests/p256/fixtures/nordpass/creation.json",
+            "tests/p256/fixtures/nordpass/session_key_authentication.json",
+        );
+    }
+
     // #[test]
     fn test_one_password_authentication() {
         let payer = Keypair::read_from_file(

--- a/tests/p256/fixtures/nordpass/authentication.json
+++ b/tests/p256/fixtures/nordpass/authentication.json
@@ -1,0 +1,13 @@
+{
+  "id": "YzFjYzdmNTYtNjZhOS00MmJmLTg1YmEtYTM4OWI3NDk5ZDEz",
+  "rawId": "YzFjYzdmNTYtNjZhOS00MmJmLTg1YmEtYTM4OWI3NDk5ZDEz",
+  "type": "public-key",
+  "authenticatorAttachment": "platform",
+  "response": {
+    "authenticatorData": "PpZrl-Wqt-OFfBpyy2SraN1m7LT0GZORwGA7-6ujYkMdAAAAAA",
+    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoicEtrWTZSaFlfcTUzaWVVMVRkLThHUS1OSmYzNVkxMnFsdzBTTzljaGxWZyIsIm9yaWdpbiI6Imh0dHBzOi8vd3d3LnBhc3NrZXlzLWRlYnVnZ2VyLmlvIn0",
+    "signature": "MEUCIBQ0nYPtktcaF6R1_eBYSyTxaJmSqIFOD2K5qCor3FxXAiEAwj2bBmMNviboLZAPSVBZa6k4y9M5C18BXigMUM4iNbg",
+    "userHandle": "fgdOBVDphLw7jKAM4G0jI601pJpmhkS2zrVOFyP1Z8w",
+    "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEa3_1JsnCFiN1h7VGot84m_ycNMDiaUnJJTILhfvOK7si3nKmUaxEzd4uN9XA_f4C2g6IY5-BvyuIRvBzgAgjnQ"
+  }
+}

--- a/tests/p256/fixtures/nordpass/creation.json
+++ b/tests/p256/fixtures/nordpass/creation.json
@@ -1,0 +1,13 @@
+{
+  "id": "YzFjYzdmNTYtNjZhOS00MmJmLTg1YmEtYTM4OWI3NDk5ZDEz",
+  "rawId": "YzFjYzdmNTYtNjZhOS00MmJmLTg1YmEtYTM4OWI3NDk5ZDEz",
+  "type": "public-key",
+  "authenticatorAttachment": "platform",
+  "response": {
+    "authenticatorData": "PpZrl-Wqt-OFfBpyy2SraN1m7LT0GZORwGA7-6ujYkMdAAAAAA",
+    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiRmE4NHA5dlBRT0FkSmRRV2JFWHNCR3NPM2FjeWNSSGZxcks2WnJzMkdMRSIsIm9yaWdpbiI6Imh0dHBzOi8vd3d3LnBhc3NrZXlzLWRlYnVnZ2VyLmlvIn0",
+    "signature": "MEUCIQDCwvoGwaZ2OwTL_ZnX1n27aQqpdFArs68bHi9LD2gA-gIgOEynjziV0pFrLVRAoxU-f9CU1u-N3NyUsjD49km1-M0",
+    "userHandle": "fgdOBVDphLw7jKAM4G0jI601pJpmhkS2zrVOFyP1Z8w",
+    "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEa3_1JsnCFiN1h7VGot84m_ycNMDiaUnJJTILhfvOK7si3nKmUaxEzd4uN9XA_f4C2g6IY5-BvyuIRvBzgAgjnQ"
+  }
+}

--- a/tests/p256/fixtures/nordpass/session_key_authentication.json
+++ b/tests/p256/fixtures/nordpass/session_key_authentication.json
@@ -1,0 +1,13 @@
+{
+  "id": "YzFjYzdmNTYtNjZhOS00MmJmLTg1YmEtYTM4OWI3NDk5ZDEz",
+  "rawId": "YzFjYzdmNTYtNjZhOS00MmJmLTg1YmEtYTM4OWI3NDk5ZDEz",
+  "type": "public-key",
+  "authenticatorAttachment": "platform",
+  "response": {
+    "authenticatorData": "PpZrl-Wqt-OFfBpyy2SraN1m7LT0GZORwGA7-6ujYkMdAAAAAA",
+    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiMlJwbnZtTzN0NHdCakdXZWF0NzZQTGRVM2tfUDVlMTFwNGxybFI0T3psWSIsIm9yaWdpbiI6Imh0dHBzOi8vd3d3LnBhc3NrZXlzLWRlYnVnZ2VyLmlvIn0",
+    "signature": "MEUCIQDxroXmCdZe51sJ-f-kcTBiH-JcEpm5XKVU-a5sNHY7OgIgIkQsx-V51rOSLf8y3zmz3ktu25aikajmuWKSsXhYkkI",
+    "userHandle": "fgdOBVDphLw7jKAM4G0jI601pJpmhkS2zrVOFyP1Z8w",
+    "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEa3_1JsnCFiN1h7VGot84m_ycNMDiaUnJJTILhfvOK7si3nKmUaxEzd4uN9XA_f4C2g6IY5-BvyuIRvBzgAgjnQ"
+  }
+}

--- a/tests/p256/utils/parser.rs
+++ b/tests/p256/utils/parser.rs
@@ -64,6 +64,10 @@ pub fn parse_webauthn_fixture(json_data: &str) -> Result<WebAuthnData, Box<dyn s
     let cross_origin = client_data_json_decoded_json["crossOrigin"]
         .as_bool()
         .unwrap_or(false);
+    let has_cross_origin = client_data_json_decoded_json
+        .as_object()
+        .map(|object| object.contains_key("crossOrigin"))
+        .unwrap_or(false);
     let is_http = client_data_json_decoded_json["origin"]
         .as_str()
         .unwrap()
@@ -84,13 +88,15 @@ pub fn parse_webauthn_fixture(json_data: &str) -> Result<WebAuthnData, Box<dyn s
                 .and_then(|port_str| port_str.parse::<u16>().ok())
         });
 
-    let client_data_reconstruction_params = ClientDataJsonReconstructionParams::new(
-        auth_type,
-        cross_origin,
-        is_http,
-        has_google_extra,
-        port,
-    );
+    let client_data_reconstruction_params =
+        ClientDataJsonReconstructionParams::new_with_optional_cross_origin(
+            auth_type,
+            cross_origin,
+            has_cross_origin,
+            is_http,
+            has_google_extra,
+            port,
+        );
     // Return the extracted data
     Ok(WebAuthnData {
         signature,


### PR DESCRIPTION
## Summary

Adds support for WebAuthn `clientDataJSON` payloads that omit the `crossOrigin` field, as seen in NordPass.

## Changes

- Reuses the existing reconstruction params byte with a new `0x08` `omitCrossOrigin` flag.
- Keeps default behavior backwards-compatible: `crossOrigin` is still included unless explicitly omitted.
- Updates Rust and TS reconstruction/parsing logic to preserve `crossOrigin` field presence.
- Adds NordPass fixtures for initialization, authentication, and session-key authentication.
- Adds tests covering omitted `crossOrigin` across init, normal auth, session auth, and TS SDK parsing.
