### PR TITLE
fix: handle skipped slots in nonce validation

### DIFF
--- a/src/utils/nonce.rs
+++ b/src/utils/nonce.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use core::ops::Deref;
 use pinocchio::{
     account_info::{AccountInfo, Ref},
     program_error::ProgramError,
@@ -7,7 +8,7 @@ use pinocchio::{
 
 use crate::{
     errors::ExternalSignatureProgramError,
-    utils::{get_stack_height, SlotHashes},
+    utils::{get_stack_height, SlotHash, SlotHashes},
 };
 
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
@@ -53,6 +54,59 @@ pub struct NonceData<'a> {
     pub slothash: [u8; 32],
 }
 
+/// Searches only toward newer SlotHashes entries after the direct numeric-slot
+/// index misses.
+///
+/// Reverse linear search is intentional here. With a maximum valid distance of
+/// 149 slots and Solana's current roughly 1% skip rate, only a small number of
+/// entries are normally missing. SBF benchmarks showed that linear search is
+/// cheaper than binary search under those conditions, while remaining bounded
+/// to this 150-slot validity window.
+#[inline(always)]
+fn reverse_linear_search_slot_hash<'slot_hashes, T>(
+    slothashes_sysvar: &'slot_hashes SlotHashes<T>,
+    expected_slot: u64,
+    search_end: usize,
+) -> Result<&'slot_hashes SlotHash, ProgramError>
+where
+    T: Deref<Target = [u8]>,
+{
+    for index in (0..search_end).rev() {
+        let candidate = slothashes_sysvar.get_slot_hash(index)?;
+        if candidate.height == expected_slot {
+            return Ok(candidate);
+        }
+    }
+
+    Err(ExternalSignatureProgramError::InvalidSlothashIndex.into())
+}
+
+#[inline(always)]
+fn find_slot_hash_with_fallback<'slot_hashes, T>(
+    slothashes_sysvar: &'slot_hashes SlotHashes<T>,
+    expected_slot: u64,
+    expected_index: usize,
+) -> Result<&'slot_hashes SlotHash, ProgramError>
+where
+    T: Deref<Target = [u8]>,
+{
+    let slothashes_len = slothashes_sysvar.get_slothashes_len() as usize;
+
+    if expected_index < slothashes_len {
+        let candidate = slothashes_sysvar.get_slot_hash(expected_index)?;
+        if candidate.height == expected_slot {
+            return Ok(candidate);
+        }
+    }
+
+    let search_end = expected_index.min(slothashes_len);
+    if search_end == 0 {
+        return Err(ExternalSignatureProgramError::InvalidSlothashIndex.into());
+    }
+
+    reverse_linear_search_slot_hash(slothashes_sysvar, expected_slot, search_end)
+}
+
 /// Validates a nonce signature
 pub fn validate_nonce<'a>(
     slothashes_sysvar: SlotHashes<Ref<'a, [u8]>>,
@@ -87,8 +141,12 @@ pub fn validate_nonce<'a>(
         return Err(ExternalSignatureProgramError::ExpiredSlothash.into());
     }
 
-    // Get the slot hash at the index difference
-    let slot_hash = slothashes_sysvar.get_slot_hash(index_difference as usize)?;
+    let expected_slot = most_recent_slot_hash
+        .height
+        .checked_sub(index_difference as u64)
+        .ok_or(ExternalSignatureProgramError::InvalidTruncatedSlot)?;
+    let slot_hash =
+        find_slot_hash_with_fallback(&slothashes_sysvar, expected_slot, index_difference as usize)?;
 
     Ok(NonceData {
         signer_key: nonce_signer.key(),
@@ -99,6 +157,57 @@ pub fn validate_nonce<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn populate_slot_hashes(heights: &[u64]) -> Vec<u64> {
+        // Store the test data as u64s so it is aligned for SlotHash's zero-copy reads.
+        let mut data = Vec::with_capacity(1 + heights.len() * 5);
+        data.push(heights.len() as u64);
+        for height in heights {
+            data.push(*height);
+            data.extend([0; 4]);
+        }
+        data
+    }
+
+    fn slot_hashes_as_bytes(data: &[u64]) -> &[u8] {
+        unsafe {
+            core::slice::from_raw_parts(data.as_ptr().cast::<u8>(), core::mem::size_of_val(data))
+        }
+    }
+
+    #[test]
+    fn test_find_slot_hash_uses_direct_index_for_contiguous_slots() {
+        let contiguous_data = populate_slot_hashes(&[14, 13, 12, 11, 10]);
+        let contiguous =
+            unsafe { SlotHashes::new_unchecked(slot_hashes_as_bytes(&contiguous_data)) };
+        assert_eq!(
+            find_slot_hash_with_fallback(&contiguous, 10, 4)
+                .unwrap()
+                .height,
+            10
+        );
+    }
+
+    #[test]
+    fn test_find_slot_hash_falls_back_for_skipped_slots() {
+        let skipped_data = populate_slot_hashes(&[14, 10, 9]);
+        let skipped = unsafe { SlotHashes::new_unchecked(slot_hashes_as_bytes(&skipped_data)) };
+        assert_eq!(
+            find_slot_hash_with_fallback(&skipped, 10, 4)
+                .unwrap()
+                .height,
+            10
+        );
+    }
+
+    #[test]
+    fn test_find_slot_hash_rejects_absent_target_and_len_index() {
+        let data = populate_slot_hashes(&[14, 12, 9]);
+        let slothashes = unsafe { SlotHashes::new_unchecked(slot_hashes_as_bytes(&data)) };
+
+        assert!(find_slot_hash_with_fallback(&slothashes, 10, 4).is_err());
+        assert!(slothashes.get_slot_hash(3).is_err());
+    }
 
     #[test]
     fn test_truncated_slot_new() {

--- a/src/utils/slothashes.rs
+++ b/src/utils/slothashes.rs
@@ -69,7 +69,7 @@ where
     /// Returns the slot hash at the specified index.
     #[inline(always)]
     pub fn get_slot_hash(&self, index: usize) -> Result<&SlotHash, ProgramError> {
-        if index > self.get_slothashes_len() as usize {
+        if index >= self.get_slothashes_len() as usize {
             return Err(ExternalSignatureProgramError::InvalidSlothashIndex.into());
         }
         unsafe { Ok(self.get_slot_hash_unchecked(index)) }

--- a/tests/p256/account_authentication.rs
+++ b/tests/p256/account_authentication.rs
@@ -2,7 +2,10 @@ use crate::{
     p256::utils::{
         authentication::authenticate_passkey_account,
         initialization::initialize_passkey_account,
-        svm::{create_and_send_svm_transaction, get_valid_slothash, initialize_svm},
+        svm::{
+            create_and_send_svm_transaction, get_valid_slothash, initialize_svm,
+            set_slothash_sysvar_with_skips,
+        },
     },
     svm::{create_and_assert_svm_transaction, get_expired_slothash},
 };
@@ -154,6 +157,45 @@ fn test_authentication_invalid_truncated_slot(create_account_path: &str, auth_pa
     .unwrap();
 }
 
+fn authenticate_with_skipped_slots(
+    create_account_path: &str,
+    auth_path: &str,
+    distance: u64,
+    skipped_slots: u64,
+) {
+    let payer = Keypair::read_from_file(
+        "tests/p256/keypairs/sinf1bu1CMQaMzeDoysAU7dAp2gs5j2V3vM9W5ZXAyB.json",
+    )
+    .unwrap();
+    let (mut svm, program_id) = initialize_svm(vec![payer.pubkey()]);
+
+    // The fixture is signed with the hash at index 42. With contiguous slots,
+    // the numeric slot distance and SlotHashes array index are both 42.
+    let (_hash, truncated_slot) = get_valid_slothash(&svm);
+    let (account_pubkey, _public_key, instructions) = initialize_passkey_account(
+        create_account_path,
+        &payer.pubkey(),
+        &truncated_slot,
+        &program_id,
+    )
+    .unwrap();
+    create_and_send_svm_transaction(&mut svm, instructions, &payer.pubkey(), vec![&payer]).unwrap();
+
+    set_slothash_sysvar_with_skips(&mut svm, 42, distance, skipped_slots);
+
+    let instructions = authenticate_passkey_account(
+        auth_path,
+        &mut svm,
+        &account_pubkey,
+        &payer.pubkey(),
+        truncated_slot,
+        &program_id,
+    )
+    .unwrap();
+
+    create_and_send_svm_transaction(&mut svm, instructions, &payer.pubkey(), vec![&payer]).unwrap();
+}
+
 #[cfg(test)]
 mod test_authentication {
     use super::*;
@@ -212,5 +254,27 @@ mod test_authentication {
             "tests/p256/fixtures/chrome/creation.json",
             "tests/p256/fixtures/chrome/authentication.json",
         );
+    }
+
+    #[test]
+    fn test_skipped_slots_use_fallback_lookup() {
+        authenticate_with_skipped_slots(
+            "tests/p256/fixtures/chrome/creation.json",
+            "tests/p256/fixtures/chrome/authentication.json",
+            42,
+            41,
+        );
+    }
+
+    #[test]
+    fn test_skipped_slot_fallback_matrix() {
+        for skipped_slots in [1, 2, 3, 4, 8, 16, 32, 64, 148] {
+            authenticate_with_skipped_slots(
+                "tests/p256/fixtures/chrome/creation.json",
+                "tests/p256/fixtures/chrome/authentication.json",
+                skipped_slots + 1,
+                skipped_slots,
+            );
+        }
     }
 }

--- a/tests/p256/utils/svm.rs
+++ b/tests/p256/utils/svm.rs
@@ -117,6 +117,45 @@ pub fn set_slothash_sysvar(svm: &mut LiteSVM) {
     svm.set_sysvar(&SlotHashes::new(&slothashes));
 }
 
+pub fn set_slothash_sysvar_with_skips(
+    svm: &mut LiteSVM,
+    signed_slot_index: usize,
+    distance: u64,
+    skipped_slots: u64,
+) {
+    assert!(distance < 150);
+    assert!(skipped_slots < distance);
+
+    let current_slothashes = svm.get_sysvar::<SlotHashes>();
+    let signed_slot = current_slothashes[signed_slot_index];
+    let newest_height = signed_slot.0 + distance;
+    let first_retained_height = signed_slot.0 + skipped_slots + 1;
+    let mut slothashes = Vec::with_capacity(512);
+
+    for height in (signed_slot.0..=newest_height).rev() {
+        if height > signed_slot.0 && height < first_retained_height {
+            continue;
+        }
+
+        let hash = if height == signed_slot.0 {
+            signed_slot.1
+        } else {
+            let hash_bytes: [u8; 32] = Sha256::digest(height.to_le_bytes()).into();
+            Hash::from(hash_bytes)
+        };
+        slothashes.push((height, hash));
+    }
+
+    let mut older_height = signed_slot.0;
+    while slothashes.len() < 512 && older_height > 0 {
+        older_height -= 1;
+        let hash_bytes: [u8; 32] = Sha256::digest(older_height.to_le_bytes()).into();
+        slothashes.push((older_height, Hash::from(hash_bytes)));
+    }
+
+    svm.set_sysvar(&SlotHashes::new(&slothashes));
+}
+
 pub fn get_valid_slothash(svm: &LiteSVM) -> ([u8; 32], TruncatedSlot) {
     let slothashes = svm.get_sysvar::<SlotHashes>();
     // Meaning of life


### PR DESCRIPTION
## Summary

- Keep the direct SlotHashes index lookup as the fast path.
- On mismatch, reconstruct the full signed slot and scan only toward newer entries.
- Fix the SlotHashes bounds check and cover skipped-slot layouts in LiteSVM.

Skipped slots are absent from the sysvar, so numeric slot distance is not always the correct array index.